### PR TITLE
chore(package): Upgrade to go 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.20'
   GOLANGCI_VERSION: 'v1.52.2'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
-GO_REQUIRED_VERSION ?= 1.19
+GO_REQUIRED_VERSION ?= 1.20
 GOLANGCILINT_VERSION ?= 1.52.2
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider $(GO_PROJECT)/cmd/generator
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/provider-github
 
-go 1.19
+go 1.20
 
 require (
 	github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20221012013934-bce61005a175


### PR DESCRIPTION
Updates go to version 1.20 and runs `go mod tidy`.

Before:
  `go 1.19`

Before:
  `go 1.17`

After:
  `go 1.20`