### PR TITLE
fix reference to team in emugroupmapping

### DIFF
--- a/apis/team/v1alpha1/zz_emugroupmapping_types.go
+++ b/apis/team/v1alpha1/zz_emugroupmapping_types.go
@@ -26,6 +26,7 @@ type EmuGroupMappingInitParameters struct {
 	// Slug of the GitHub team
 	// Slug of the GitHub team.
 	// +crossplane:generate:reference:type=Team
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/pkg/resource.ExtractParamPath("slug",true)
 	TeamSlug *string `json:"teamSlug,omitempty" tf:"team_slug,omitempty"`
 
 	// Reference to a Team to populate teamSlug.
@@ -61,6 +62,7 @@ type EmuGroupMappingParameters struct {
 	// Slug of the GitHub team
 	// Slug of the GitHub team.
 	// +crossplane:generate:reference:type=Team
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/pkg/resource.ExtractParamPath("slug",true)
 	// +kubebuilder:validation:Optional
 	TeamSlug *string `json:"teamSlug,omitempty" tf:"team_slug,omitempty"`
 

--- a/apis/team/v1alpha1/zz_generated.resolvers.go
+++ b/apis/team/v1alpha1/zz_generated.resolvers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	v1alpha1 "github.com/coopnorge/provider-github/apis/repo/v1alpha1"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
+	resource "github.com/crossplane/upjet/pkg/resource"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -22,7 +23,7 @@ func (mg *EmuGroupMapping) ResolveReferences(ctx context.Context, c client.Reade
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.TeamSlug),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("slug", true),
 		Reference:    mg.Spec.ForProvider.TeamSlugRef,
 		Selector:     mg.Spec.ForProvider.TeamSlugSelector,
 		To: reference.To{
@@ -38,7 +39,7 @@ func (mg *EmuGroupMapping) ResolveReferences(ctx context.Context, c client.Reade
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.TeamSlug),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("slug", true),
 		Reference:    mg.Spec.InitProvider.TeamSlugRef,
 		Selector:     mg.Spec.InitProvider.TeamSlugSelector,
 		To: reference.To{

--- a/config/emugroupmapping/config.go
+++ b/config/emugroupmapping/config.go
@@ -1,6 +1,8 @@
 package emugroupmapping
 
-import "github.com/crossplane/upjet/pkg/config"
+import (
+	"github.com/crossplane/upjet/pkg/config"
+)
 
 // Configure github_emu_group_mapping resources
 func Configure(p *config.Provider) {
@@ -9,7 +11,8 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "team"
 
 		r.References["team_slug"] = config.Reference{
-			Type: "Team",
+			Type:      "Team",
+			Extractor: `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("slug",true)`,
 		}
 	})
 }

--- a/config/external_name.go
+++ b/config/external_name.go
@@ -32,11 +32,11 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	// Imported by using the following format: {{ team_id/slug }}:{{ repository }}
 	// The id in the state needs to use the numberic id of the team plus the repository. Cannot make external_name nice
 	"github_team_repository": config.IdentifierFromProvider,
-	// EMU group mappings can be imported using the "group_id" attribute
-	"github_emu_group_mapping": config.IdentifierFromProvider,
 	// This cannot be imported.
-	"github_team_membership": config.IdentifierFromProvider,
+	"github_emu_group_mapping": config.IdentifierFromProvider,
 	// Imported by using the following format: {{ team_id }}:{{ username }} or {{ team_name }}:{{ username }}
+	"github_team_membership": config.IdentifierFromProvider,
+	// This cannot be imported.
 	"github_actions_secret":          config.IdentifierFromProvider,
 	"github_actions_variable":        config.IdentifierFromProvider,
 	"github_enterprise_organization": config.IdentifierFromProvider,


### PR DESCRIPTION
The reference to the team did not specify that the slug must be used instead of the ID, so teamSlugSelector and teamSlugRef did not work. I have fixed it and tested both of them.

Also fixed the placing of commends in external_name.go, which got messed up with the earlier rebase.