### PR TITLE
feat: Add securityAndAnalysis to lateInitializer

### DIFF
--- a/config/repository/config.go
+++ b/config/repository/config.go
@@ -8,7 +8,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "repo"
 
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"private", "default_branch","securityAndAnalysis"},
+			IgnoredFields: []string{"private", "default_branch", "securityAndAnalysis"},
 		}
 	})
 }


### PR DESCRIPTION
Crossplane will fetch the state of the real world before updating the resource. If repository transistions
from internal to public it will read the state of securityAndAnalysis and merge that with what is set
from the managed resource. Github does not allow `.securityAndAnalysis.advancedSecurity` to be set when
public so this causes problems going form internal to public.

closes: https://github.com/coopnorge/provider-github/issues/34
ref: https://github.com/crossplane/upjet/blob/main/docs/configuring-a-resource.md#further-details-on-late-initialization
