### PR TITLE
Make ProviderConfig description mention github instead of template

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -32,7 +32,7 @@ type ProviderConfigStatus struct {
 
 // +kubebuilder:object:root=true
 
-// A ProviderConfig configures a Template provider.
+// ProviderConfig configures how the provider will connect to Github.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1

--- a/package/crds/github.upbound.io_providerconfigs.yaml
+++ b/package/crds/github.upbound.io_providerconfigs.yaml
@@ -29,7 +29,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfig configures a Template provider.
+        description: ProviderConfig configures how the provider will connect to Github.
         properties:
           apiVersion:
             description: |-


### PR DESCRIPTION
State what the providerconfig does, instead of the description that comes with the template