### PR TITLE
fix: update source link to fix url

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -4,7 +4,7 @@ metadata:
   name: provider-github
   annotations:
     meta.crossplane.io/maintainer: Coop Norge SA
-    meta.crossplane.io/source: https://github.com/coopnorge/provider-github
+    meta.crossplane.io/source: github.com/coopnorge/provider-github
     meta.crossplane.io/license: Apache-2.0
     meta.crossplane.io/description: |
       The Github Crossplane provider adds support for 


### PR DESCRIPTION
URL in upbound marketplace is not renderd correctly. It is
rendered as `https://https//github.com/coopnorge/provider-github`

Removing the https part in the sourcecode might fix the problem
