### PR TITLE
feat: add support for retry_delay_ms, max_retries, retryable_errors

### DIFF
--- a/internal/clients/github.go
+++ b/internal/clients/github.go
@@ -40,6 +40,9 @@ const (
 	keyAppAuthPemFile        = "pem_file"
 	keyWriteDelayMs          = "write_delay_ms"
 	keyReadDelayMs           = "read_delay_ms"
+	keyRetryDelayMs          = "retry_delay_ms"
+	keyMaxRetries            = "max_retries"
+	keyRetryableErrors       = "retryable_errors"
 )
 
 type appAuth struct {
@@ -49,12 +52,15 @@ type appAuth struct {
 }
 
 type githubConfig struct {
-	BaseURL      *string    `json:"base_url,omitempty"`
-	Owner        *string    `json:"owner,omitempty"`
-	Token        *string    `json:"token,omitempty"`
-	AppAuth      *[]appAuth `json:"app_auth,omitempty"`
-	WriteDelayMs *int       `json:"write_delay_ms,omitempty"`
-	ReadDelayMs  *int       `json:"read_delay_ms,omitempty"`
+	BaseURL         *string    `json:"base_url,omitempty"`
+	Owner           *string    `json:"owner,omitempty"`
+	Token           *string    `json:"token,omitempty"`
+	AppAuth         *[]appAuth `json:"app_auth,omitempty"`
+	WriteDelayMs    *int       `json:"write_delay_ms,omitempty"`
+	ReadDelayMs     *int       `json:"read_delay_ms,omitempty"`
+	RetryDelayMs    *int       `json:"retry_delay_ms,omitempty"`
+	MaxRetries      *int       `json:"max_retries,omitempty"`
+	RetryableErrors []int      `json:"retryable_errors,omitempty"`
 }
 
 func terraformProviderConfigurationBuilder(creds githubConfig) (terraform.ProviderConfiguration, error) {
@@ -96,6 +102,18 @@ func terraformProviderConfigurationBuilder(creds githubConfig) (terraform.Provid
 
 	if creds.ReadDelayMs != nil {
 		cnf[keyReadDelayMs] = *creds.ReadDelayMs
+	}
+
+	if creds.RetryDelayMs != nil {
+		cnf[keyRetryDelayMs] = *creds.RetryDelayMs
+	}
+
+	if creds.MaxRetries != nil {
+		cnf[keyMaxRetries] = *creds.MaxRetries
+	}
+
+	if creds.RetryableErrors != nil {
+		cnf[keyRetryableErrors] = creds.RetryableErrors
 	}
 
 	return cnf, nil


### PR DESCRIPTION
When a project secret is out of date and that you have a webhook resource the terraform provider spams github until rate limit. By adding the possibility to configure retry_delay_ms, max_retries and retryable_errors it is posisble to avoid this. I have tested this on my end with success by setting this:
```
{"owner":"lacroi-m-insta","token":"xxxx","write_delay_ms":60000,"read_delay_ms":60000,"retry_delay_ms":60000,"max_retries":1,"retryable_errors":[401]}
```
As the token of the matching secret.

These values are only available in the versions of TERRAFORM_PROVIDER_VERSION above 6.2.1