### PR TITLE
Prevent re-initialising terraform setups for the same providerconfig

### DIFF
--- a/internal/clients/github.go
+++ b/internal/clients/github.go
@@ -159,7 +159,6 @@ const (
 func TerraformSetupBuilder(tfProvider *schema.Provider) terraform.SetupFn {
 	var tfSetupLock sync.RWMutex
 	tfSetups := make(map[string]CachedTerraformSetup)
-
 	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {
 		ps := terraform.Setup{}
 


### PR DESCRIPTION
### Description of your changes

Observed behaviour where the /organizations/:organization_id endpoint has unusually high API usage. After some investigation, found that Terraform provider is being reconfigured for every reconciliation of every resource.

<img width="2532" height="1170" alt="image" src="https://github.com/user-attachments/assets/52040035-d224-4128-8a6e-edd463e98579" />

Given that the terraform providers exist at the ProviderConfig level, the terraform provider can be shared between resources. This change keeps a cache of tfSetups indexed by the ProviderConfig name. If the tfSetup is already available in the map, this will be used rather than creating a new terraform provider.

The tfSetups are scoped to the SetupFn and have a mutex lock to ensure only one ProviderConfig is being configured at a time. Note: if many ProviderConfigs are being used, there will be an initial delay setting up additional providers on startup due to mutex lock.

I have:

- [] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This has been tested locally against my private account creating 4xRepository and 2xProviderConfig and expecting the provider to only be configured twice (once for each ProviderConfig)

[contribution process]: https://git.io/fj2m9
