### PR TITLE
add Kael Baldwin as a maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -10,5 +10,6 @@ organization](https://github.com/crossplane-contrib/) will list their repository
 * Atze de Vries <the.atz@gmail.com> ([Atze de Vries](https://github.com/atzedevries))
 * Pravin Dahal <pravindahal@gmail.com> ([Pravin Dahal](https://github.com/pravindahal))
 * Michael Fornaro ([Michael Fornaro](https://github.com/xunholy))
+* Kaelen Baldwin <kaelen.baldwin@bayer.com> ([Kael Baldwin](https://github.com/KaelBaldwin))
 
 See [CODEOWNERS](./CODEOWNERS) for automatic PR assignment.


### PR DESCRIPTION
### Description of your changes

Adds KaelBaldwin as a Maintainer of this GitHub Crossplane Provider.

I have:

- [x] Read and followed Crossplane's [contribution process].

I'm looking forward to helping out with this provider! 