### PR TITLE
fix(repository): stop archive_on_destroy delete from wedging

### DIFF
--- a/config/cluster/repository/config.go
+++ b/config/cluster/repository/config.go
@@ -14,18 +14,34 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{"private", "default_branch"},
 		}
 
-		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
-			if diff == nil || diff.Destroy {
-				return diff, nil
-			}
-			if ppDiff, ok := diff.Attributes["security_and_analysis.#"]; ok && ppDiff.Old == "" && ppDiff.New == "" {
-				delete(diff.Attributes, "security_and_analysis.#")
-			}
-			if ppDiff, ok := diff.Attributes["topics.#"]; ok && ppDiff.Old == "" && ppDiff.New == "" {
-				delete(diff.Attributes, "topics.#")
-			}
-
-			return diff, nil
-		}
+		r.TerraformCustomDiff = repositoryCustomDiff
 	})
+}
+
+// repositoryCustomDiff sanitizes the computed Terraform diff for
+// github_repository resources.
+func repositoryCustomDiff(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	if diff == nil || diff.Destroy {
+		return diff, nil
+	}
+	// Drop spurious no-op diffs on computed/optional collections.
+	dropAttrDiff(diff, "security_and_analysis.#", "", "")
+	dropAttrDiff(diff, "topics.#", "", "")
+	// GitHub does not support unarchiving a repository through this resource, so
+	// an archived repository whose desired state omits archived=true produces a
+	// perpetual archived: true->false diff. Beyond being a no-op update loop,
+	// this diff leaks into the destroy path: the Terraform delete reads the
+	// diff's archived=false and re-PATCHes the already-archived (read-only)
+	// repository, which returns HTTP 403 and wedges deletion forever. Drop it.
+	dropAttrDiff(diff, "archived", "true", "false")
+
+	return diff, nil
+}
+
+// dropAttrDiff removes key from the diff when its computed change matches the
+// given oldVal->newVal transition, suppressing a spurious diff.
+func dropAttrDiff(diff *terraform.InstanceDiff, key, oldVal, newVal string) {
+	if d, ok := diff.Attributes[key]; ok && d.Old == oldVal && d.New == newVal {
+		delete(diff.Attributes, key)
+	}
 }

--- a/config/cluster/repository/config_test.go
+++ b/config/cluster/repository/config_test.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// When a repository is archived on GitHub but the desired state does not set
+// archived=true, Terraform computes a spurious archived: true->false diff.
+// GitHub does not support unarchiving via this path, and worse: on delete this
+// diff makes the terraform delete function re-PATCH the already-archived
+// (read-only) repository, which returns HTTP 403 and wedges the managed
+// resource forever. The diff must be dropped.
+func TestRepositoryCustomDiff_StripsUnarchiveFlip(t *testing.T) {
+	diff := &terraform.InstanceDiff{
+		Attributes: map[string]*terraform.ResourceAttrDiff{
+			"archived": {Old: "true", New: "false"},
+		},
+	}
+
+	out, err := repositoryCustomDiff(diff, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := out.Attributes["archived"]; ok {
+		t.Fatalf("expected archived true->false diff to be stripped, but it is still present: %#v", out.Attributes["archived"])
+	}
+}
+
+// A genuine request to archive (false->true) must be preserved so users can
+// still archive repositories through the resource.
+func TestRepositoryCustomDiff_PreservesArchiveRequest(t *testing.T) {
+	diff := &terraform.InstanceDiff{
+		Attributes: map[string]*terraform.ResourceAttrDiff{
+			"archived": {Old: "false", New: "true"},
+		},
+	}
+
+	out, err := repositoryCustomDiff(diff, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	d, ok := out.Attributes["archived"]
+	if !ok {
+		t.Fatal("expected archived false->true diff to be preserved, but it was removed")
+	}
+	if d.Old != "false" || d.New != "true" {
+		t.Fatalf("archived diff altered: got Old=%q New=%q", d.Old, d.New)
+	}
+}

--- a/config/namespaced/repository/config.go
+++ b/config/namespaced/repository/config.go
@@ -14,18 +14,34 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{"private", "default_branch"},
 		}
 
-		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
-			if diff == nil || diff.Destroy {
-				return diff, nil
-			}
-			if ppDiff, ok := diff.Attributes["security_and_analysis.#"]; ok && ppDiff.Old == "" && ppDiff.New == "" {
-				delete(diff.Attributes, "security_and_analysis.#")
-			}
-			if ppDiff, ok := diff.Attributes["topics.#"]; ok && ppDiff.Old == "" && ppDiff.New == "" {
-				delete(diff.Attributes, "topics.#")
-			}
-
-			return diff, nil
-		}
+		r.TerraformCustomDiff = repositoryCustomDiff
 	})
+}
+
+// repositoryCustomDiff sanitizes the computed Terraform diff for
+// github_repository resources.
+func repositoryCustomDiff(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	if diff == nil || diff.Destroy {
+		return diff, nil
+	}
+	// Drop spurious no-op diffs on computed/optional collections.
+	dropAttrDiff(diff, "security_and_analysis.#", "", "")
+	dropAttrDiff(diff, "topics.#", "", "")
+	// GitHub does not support unarchiving a repository through this resource, so
+	// an archived repository whose desired state omits archived=true produces a
+	// perpetual archived: true->false diff. Beyond being a no-op update loop,
+	// this diff leaks into the destroy path: the Terraform delete reads the
+	// diff's archived=false and re-PATCHes the already-archived (read-only)
+	// repository, which returns HTTP 403 and wedges deletion forever. Drop it.
+	dropAttrDiff(diff, "archived", "true", "false")
+
+	return diff, nil
+}
+
+// dropAttrDiff removes key from the diff when its computed change matches the
+// given oldVal->newVal transition, suppressing a spurious diff.
+func dropAttrDiff(diff *terraform.InstanceDiff, key, oldVal, newVal string) {
+	if d, ok := diff.Attributes[key]; ok && d.Old == oldVal && d.New == newVal {
+		delete(diff.Attributes, key)
+	}
 }

--- a/config/namespaced/repository/config_test.go
+++ b/config/namespaced/repository/config_test.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// When a repository is archived on GitHub but the desired state does not set
+// archived=true, Terraform computes a spurious archived: true->false diff.
+// GitHub does not support unarchiving via this path, and worse: on delete this
+// diff makes the terraform delete function re-PATCH the already-archived
+// (read-only) repository, which returns HTTP 403 and wedges the managed
+// resource forever. The diff must be dropped.
+func TestRepositoryCustomDiff_StripsUnarchiveFlip(t *testing.T) {
+	diff := &terraform.InstanceDiff{
+		Attributes: map[string]*terraform.ResourceAttrDiff{
+			"archived": {Old: "true", New: "false"},
+		},
+	}
+
+	out, err := repositoryCustomDiff(diff, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := out.Attributes["archived"]; ok {
+		t.Fatalf("expected archived true->false diff to be stripped, but it is still present: %#v", out.Attributes["archived"])
+	}
+}
+
+// A genuine request to archive (false->true) must be preserved so users can
+// still archive repositories through the resource.
+func TestRepositoryCustomDiff_PreservesArchiveRequest(t *testing.T) {
+	diff := &terraform.InstanceDiff{
+		Attributes: map[string]*terraform.ResourceAttrDiff{
+			"archived": {Old: "false", New: "true"},
+		},
+	}
+
+	out, err := repositoryCustomDiff(diff, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	d, ok := out.Attributes["archived"]
+	if !ok {
+		t.Fatal("expected archived false->true diff to be preserved, but it was removed")
+	}
+	if d.Old != "false" || d.New != "true" {
+		t.Fatalf("archived diff altered: got Old=%q New=%q", d.Old, d.New)
+	}
+}


### PR DESCRIPTION
## Problem

Deleting a `Repository` MR configured with `archiveOnDestroy: true` (tf `archive_on_destroy`) wedges the resource forever. Observed status:

```
CannotDeleteExternalResource   async delete failed: failed to delete the resource:
[PATCH .../repos/<org>/<repo>: 403 Repository was archived so is read-only.]
```

The repo *does* get archived, but the MR never finishes deleting — the async delete retries the same 403 indefinitely.

## Root cause

`archived` is `Optional` with `Default: false`. Once a repo is archived on GitHub, an MR whose desired state omits `archived=true` makes upjet compute a perpetual `archived: true→false` ("unarchive") diff. GitHub doesn't support unarchiving through this resource — but the real damage is on delete:

- `Observe` computes the `instanceDiff` (including `archived: true→false`).
- `Delete` sets `Destroy=true` on **that same diff** and calls the terraform-plugin-sdk `Apply`.
- The SDK merges state+diff into the delete's `ResourceData`, so `d.Get("archived")` returns `false`.
- terraform-provider-github's delete function therefore takes its "not archived yet" branch and re-PATCHes the **already-archived, read-only** repo → **403** → upjet's async delete fails and retries forever.

## Fix

Strip the `archived: true→false` flip in `TerraformCustomDiff`, alongside the existing `security_and_analysis`/`topics` strips. The destroy path then reads `archived=true` from state → terraform's "already archived, nothing to do" → returns nil → upjet marks the resource deleted → finalizer releases. It also stops the no-op update loop on archived repos during normal reconcile.

Applied to both the cluster and namespaced repository configs (inline closure extracted into a testable `repositoryCustomDiff`), with unit tests written test-first.

## Expected behavior after the fix

This breaks the infinite loop, not the very first 403. On the first destroy the repo isn't archived yet (nothing to strip), so terraform still fires the full-object archive PATCH that archives the repo and 403s on the read-only fields. The fix engages on the **next** reconcile (state now `archived=true` → diff stripped → clean delete). Expect one transient `CannotDeleteExternalResource` 403, then successful deletion.

## Verification

- `go test ./config/cluster/repository/ ./config/namespaced/repository/` — green
- `go vet` — clean
- `go build ./config/... ./cmd/...` — OK
- Not driven end-to-end (needs a live cluster + GitHub org); rests on the traced mechanism + unit tests.

## Notes

Workaround for the unmerged upstream fix integrations/terraform-provider-github#2866 ("Fix repository archive on destroy ..."). Related upstream reports: integrations/terraform-provider-github#2644.