### PR TITLE
fix(clients): make the terraform setup cache safe on cold start and clear of token expiry

### DIFF
--- a/internal/clients/github.go
+++ b/internal/clients/github.go
@@ -151,7 +151,21 @@ type CachedTerraformSetup struct {
 }
 
 const (
-	tfSetupCacheTTL = time.Minute * 55
+	// githubInstallationTokenLifetime is how long a GitHub App installation
+	// token stays valid after the terraform provider mints it.
+	githubInstallationTokenLifetime = time.Hour
+
+	// tfSetupMaxHold is the longest a caller may hold a Setup between taking it
+	// from the cache and making its last GitHub API call with it. The cache TTL
+	// has to leave room for this, not just for the moment of the cache read:
+	// upjet's async external client captures the Setup when an operation starts
+	// and reuses it for that whole operation, which can run for minutes. With a
+	// TTL close to the token lifetime, an operation starting near the end of the
+	// window makes its calls against an already-expired token and GitHub answers
+	// 401 Bad credentials.
+	tfSetupMaxHold = time.Minute * 30
+
+	tfSetupCacheTTL = githubInstallationTokenLifetime - tfSetupMaxHold
 )
 
 // TerraformSetupBuilder builds Terraform a terraform.SetupFn function which returns Terraform provider setup configuration

--- a/internal/clients/github.go
+++ b/internal/clients/github.go
@@ -161,74 +161,88 @@ func TerraformSetupBuilder(tfProvider *schema.Provider, l logging.Logger) terraf
 	var tfSetupLock sync.RWMutex
 	tfSetups := make(map[string]CachedTerraformSetup)
 	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {
-		ps := terraform.Setup{}
-
 		configRefName, err := getProviderConfigName(mg)
 		if err != nil {
-			return ps, errors.Wrap(err, "cannot get provider config name")
+			return terraform.Setup{}, errors.Wrap(err, "cannot get provider config name")
 		}
 
-		tfSetup, ok := tfSetups[configRefName]
-		if ok && tfSetup.expiry.After(time.Now()) {
-			return *tfSetup.setup, nil
-		}
+		return getOrBuildTerraformSetup(&tfSetupLock, tfSetups, configRefName, time.Now, tfSetupCacheTTL,
+			func() (terraform.Setup, error) {
+				ps := terraform.Setup{}
 
-		l.Debug("Locking in order to update credentials")
-		unlocked := tfSetupLock.TryLock()
-		if !unlocked {
-			// it is actually save to return the 'old' token since
-			// it is still valid for 7 hours.
-			if ok {
-				return *tfSetup.setup, nil
-			}
+				pcSpec, err := resolveProviderConfig(ctx, client, mg)
+				if err != nil {
+					return terraform.Setup{}, errors.Wrap(err, "cannot resolve provider config")
+				}
 
-			return ps, errors.New(errGitHubTokenNotReady)
-		}
-		l.Debug("Lock succedeed")
-		defer unlockMutex(&tfSetupLock, l)
+				data, err := resource.CommonCredentialExtractor(ctx, pcSpec.Credentials.Source, client, pcSpec.Credentials.CommonCredentialSelectors)
+				if err != nil {
+					return ps, errors.Wrap(err, errExtractCredentials)
+				}
 
-		pcSpec, err := resolveProviderConfig(ctx, client, mg)
-		if err != nil {
-			return terraform.Setup{}, errors.Wrap(err, "cannot resolve provider config")
-		}
+				creds := githubConfig{}
+				if data != nil {
+					if err := json.Unmarshal(data, &creds); err != nil {
+						return ps, errors.Wrap(err, errUnmarshalCredentials)
+					}
+				}
 
-		data, err := resource.CommonCredentialExtractor(ctx, pcSpec.Credentials.Source, client, pcSpec.Credentials.CommonCredentialSelectors)
-		if err != nil {
-			return ps, errors.Wrap(err, errExtractCredentials)
-		}
+				ps.Configuration, err = terraformProviderConfigurationBuilder(creds)
+				if err != nil {
+					return ps, errors.Wrap(err, errProviderConfigurationBuilder)
+				}
 
-		creds := githubConfig{}
-		if data != nil {
-			if err := json.Unmarshal(data, &creds); err != nil {
-				return ps, errors.Wrap(err, errUnmarshalCredentials)
-			}
-		}
+				if err := configureNoForkGithubClient(ctx, &ps, *tfProvider); err != nil {
+					return ps, errors.Wrap(err, "failed to configure the Terraform Github provider meta")
+				}
 
-		ps.Configuration, err = terraformProviderConfigurationBuilder(creds)
-		if err != nil {
-			return ps, errors.Wrap(err, errProviderConfigurationBuilder)
-		}
-
-		err = configureNoForkGithubClient(ctx, &ps, *tfProvider)
-		if err != nil {
-			return ps, errors.Wrap(err, "failed to configure the Terraform Github provider meta")
-		}
-
-		tfSetups[configRefName] = CachedTerraformSetup{
-			setup:  &ps,
-			expiry: time.Now().Add(tfSetupCacheTTL),
-		}
-
-		l.Info("Refreshed Github Token", "configName", configRefName, "expiry", tfSetups[configRefName].expiry)
-
-		return ps, nil
+				l.Info("Refreshed Github Token", "configName", configRefName)
+				return ps, nil
+			})
 	}
 }
 
-func unlockMutex(lock *sync.RWMutex, l logging.Logger) {
-	l.Debug("Initiating unlock")
-	lock.Unlock()
-	l.Debug("Unlock succeeded")
+// getOrBuildTerraformSetup returns a cached terraform.Setup for configRefName,
+// building (and caching) one via build if none is cached or the cached entry has
+// expired. Concurrent callers for the same ProviderConfig are collapsed to a
+// single build; the losers wait for it rather than erroring.
+func getOrBuildTerraformSetup(
+	lock *sync.RWMutex,
+	cache map[string]CachedTerraformSetup,
+	configRefName string,
+	now func() time.Time,
+	ttl time.Duration,
+	build func() (terraform.Setup, error),
+) (terraform.Setup, error) {
+	// Fast path: return a cached, unexpired setup under a read lock.
+	lock.RLock()
+	tfSetup, ok := cache[configRefName]
+	lock.RUnlock()
+	if ok && tfSetup.expiry.After(now()) {
+		return *tfSetup.setup, nil
+	}
+
+	// Slow path: block for the write lock rather than erroring. On cold start
+	// this collapses a herd of concurrent reconciles into a single build; the
+	// losers wait here and then hit the cache populated below.
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Double-checked: another goroutine may have built or refreshed the setup
+	// while we waited for the lock.
+	if tfSetup, ok := cache[configRefName]; ok && tfSetup.expiry.After(now()) {
+		return *tfSetup.setup, nil
+	}
+
+	ps, err := build()
+	if err != nil {
+		return terraform.Setup{}, err
+	}
+	cache[configRefName] = CachedTerraformSetup{
+		setup:  &ps,
+		expiry: now().Add(ttl),
+	}
+	return ps, nil
 }
 
 func configureNoForkGithubClient(ctx context.Context, ps *terraform.Setup, p schema.Provider) error {

--- a/internal/clients/github_test.go
+++ b/internal/clients/github_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/crossplane/upjet/v2/pkg/terraform"
+)
+
+// TestGetOrBuildTerraformSetup_ConcurrentColdStart reproduces the cold-start
+// thundering-herd bug: when many managed resources reconcile at once against a
+// ProviderConfig whose setup has not been cached yet, only one goroutine should
+// build the setup and every other caller should receive that same setup — never
+// an "github token not ready yet" error, and never a data race on the cache map.
+//
+// Run with -race; the buggy implementation reads the cache map without a lock
+// while another goroutine writes it under the lock, which is a fatal Go panic in
+// production.
+func TestGetOrBuildTerraformSetup_ConcurrentColdStart(t *testing.T) {
+	const n = 50
+
+	var lock sync.RWMutex
+	cache := map[string]CachedTerraformSetup{}
+
+	var buildCount int32
+	var firstBuild sync.Once
+	entered := make(chan struct{}) // closed when the first build starts (lock held)
+	release := make(chan struct{}) // holds the first build open to widen contention
+
+	build := func() (terraform.Setup, error) {
+		atomic.AddInt32(&buildCount, 1)
+		firstBuild.Do(func() { close(entered) })
+		<-release
+		return terraform.Setup{
+			Configuration: terraform.ProviderConfiguration{"token": "test-token"},
+		}, nil
+	}
+
+	// Barrier so all goroutines are released as close to simultaneously as
+	// possible, maximizing contention on the cache/lock.
+	var gate sync.WaitGroup
+	gate.Add(1)
+
+	errs := make(chan error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			gate.Wait()
+			_, err := getOrBuildTerraformSetup(&lock, cache, "provider-config", time.Now, time.Minute, build)
+			errs <- err
+		}()
+	}
+
+	gate.Done() // release the herd
+	<-entered   // a build is now in flight, holding the lock
+
+	// Give the contending goroutines time to pile onto the lock while the build
+	// is held open, so the buggy TryLock path deterministically reports the error.
+	time.Sleep(25 * time.Millisecond)
+	close(release)
+
+	wg.Wait()
+	close(errs)
+
+	var failures int
+	for err := range errs {
+		if err != nil {
+			failures++
+			if !strings.Contains(err.Error(), errGitHubTokenNotReady) {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}
+	}
+
+	if failures != 0 {
+		t.Errorf("expected 0 callers to fail, got %d/%d with %q", failures, n, errGitHubTokenNotReady)
+	}
+	if got := atomic.LoadInt32(&buildCount); got != 1 {
+		t.Errorf("expected exactly 1 build (single-flight), got %d", got)
+	}
+}
+
+// TestGetOrBuildTerraformSetup_CachesUntilExpiry verifies the cache fast path:
+// a second call within the TTL returns the cached setup without rebuilding, and
+// a call after expiry rebuilds.
+func TestGetOrBuildTerraformSetup_CachesUntilExpiry(t *testing.T) {
+	var lock sync.RWMutex
+	cache := map[string]CachedTerraformSetup{}
+
+	var buildCount int32
+	build := func() (terraform.Setup, error) {
+		atomic.AddInt32(&buildCount, 1)
+		return terraform.Setup{}, nil
+	}
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+
+	if _, err := getOrBuildTerraformSetup(&lock, cache, "pc", clock, time.Minute, build); err != nil {
+		t.Fatalf("first call: unexpected error: %v", err)
+	}
+	if _, err := getOrBuildTerraformSetup(&lock, cache, "pc", clock, time.Minute, build); err != nil {
+		t.Fatalf("second call: unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&buildCount); got != 1 {
+		t.Fatalf("expected cached second call (1 build), got %d builds", got)
+	}
+
+	// Advance past the TTL: the setup should be rebuilt.
+	now = now.Add(2 * time.Minute)
+	if _, err := getOrBuildTerraformSetup(&lock, cache, "pc", clock, time.Minute, build); err != nil {
+		t.Fatalf("post-expiry call: unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&buildCount); got != 2 {
+		t.Fatalf("expected rebuild after expiry (2 builds), got %d builds", got)
+	}
+}

--- a/internal/clients/github_test.go
+++ b/internal/clients/github_test.go
@@ -124,3 +124,19 @@ func TestGetOrBuildTerraformSetup_CachesUntilExpiry(t *testing.T) {
 		t.Fatalf("expected rebuild after expiry (2 builds), got %d builds", got)
 	}
 }
+
+// TestTFSetupCacheTTLOutlivedByToken verifies the cache expires far enough ahead
+// of the GitHub App installation token that a caller still holding a Setup —
+// notably upjet's async external client, which keeps one for a whole create or
+// update — cannot make calls with an already-expired token and get back
+// 401 Bad credentials.
+func TestTFSetupCacheTTLOutlivedByToken(t *testing.T) {
+	if tfSetupCacheTTL <= 0 {
+		t.Fatalf("tfSetupCacheTTL must be positive, got %s", tfSetupCacheTTL)
+	}
+
+	if got := tfSetupCacheTTL + tfSetupMaxHold; got > githubInstallationTokenLifetime {
+		t.Errorf("a Setup taken at the end of the TTL and held for %s outlives its %s token by %s; lower tfSetupCacheTTL",
+			tfSetupMaxHold, githubInstallationTokenLifetime, got-githubInstallationTokenLifetime)
+	}
+}


### PR DESCRIPTION
## What / Why

Two independent bugs in the `terraform.Setup` cache in `internal/clients/github.go`. Both make GitHub-backed managed resources fail in ways that look transient but aren't; they're separate commits and can be reviewed independently.

---

## 1. Cold start: concurrent reconciles error instead of waiting

On provider cold start, many managed resources reconcile concurrently against a `ProviderConfig` whose `terraform.Setup` has not been cached yet. Users see:

```
cannot initialize the Terraform plugin SDK async external client: cannot get terraform setup:
github token not ready yet
```

and the affected resources drop into a `NotSynced`/error state.

### Root cause

`TerraformSetupBuilder` returns a single closure shared by all controllers (one `tfSetups` map, one `tfSetupLock`). The slow path used a **non-blocking `TryLock()`**: the first goroutine wins the lock and performs the slow, network-bound build (`p.Configure` fetches the GitHub App installation token), while every other concurrent caller fails `TryLock()`, finds an empty cache (`ok == false`), and returns `errGitHubTokenNotReady`. On a cold start with N resources this errors ~N-1 of them until the winner populates the cache.

There is also a **data race**: the fast-path cache read (`tfSetups[configRefName]`) is performed with no lock held, while another goroutine writes the same map under the lock. Concurrent map read/write is a fatal runtime panic in Go. The `sync.RWMutex` was declared but `RLock` was never taken on the read side.

### Change

Extract the get-or-build-under-lock logic into `getOrBuildTerraformSetup` (with an injectable `build` func for testing) and:

- guard the fast-path cache read with `RLock`;
- on a cache miss, **block on `Lock()`** rather than erroring, so concurrent cold-start reconciles collapse into a single build and the losers wait for it;
- **double-check** the cache after acquiring the write lock so exactly one build runs per refresh.

This trades away the previous "return a stale-but-valid token during the refresh without blocking" behavior; briefly blocking at refresh is correct and avoids a thundering herd of rebuilds.

---

## 2. Token expiry: the refresh margin was sized for the wrong thing

A GitHub App installation token is valid for one hour and the terraform provider never refreshes it (hence the existing cache TTL, pending integrations/terraform-provider-github#2695). `tfSetupCacheTTL` was **55 minutes** — a 5-minute margin.

### Root cause

That margin only holds if a caller uses the Setup at the instant it reads it from the cache. It doesn't: **upjet's async external client captures the Setup when an operation starts and reuses it for that entire operation**, and those operations run for minutes. So an operation starting near the end of the 55-minute window makes its GitHub API calls after the token has expired, and GitHub answers:

```
async update failed: failed to update the resource:
PATCH https://api.github.com/repos/<org>/<repo>: 401 Bad credentials
```

The margin was sized for when a Setup is *read*, never for how long it is *held*.

Downstream this is worse than one failed update, because a 401'd **observe** cannot see the resource. We saw Crossplane conclude a repository didn't exist and re-issue `Create` against one that did — `external-create-failed` stamped *after* `external-create-succeeded` on the same MR — with readiness arriving ~24 minutes after creation.

### Change

Derive the TTL instead of hardcoding it, so the reason for the margin survives the next edit:

```go
githubInstallationTokenLifetime = time.Hour
tfSetupMaxHold                  = time.Minute * 30  // longest a caller may hold a Setup
tfSetupCacheTTL                 = githubInstallationTokenLifetime - tfSetupMaxHold
```

A Setup is now at most 30 minutes old when read, leaving ≥30 minutes of token validity for however long the holder keeps it. The cost is one extra token mint per `ProviderConfig` per hour. Widening the margin is monotonic — it cannot make staleness worse — so it holds even if some other path also contributes to a 401.

---

## Testing

- `TestGetOrBuildTerraformSetup_*`: race-enabled concurrency test (50 goroutines) asserting single-flight build, zero `github token not ready yet` errors, and a clean race detector. Fails on the previous `TryLock` implementation (both the errors and the data race) and passes with this change.
- `TestTFSetupCacheTTLOutlivedByToken`: asserts `tfSetupCacheTTL + tfSetupMaxHold <= githubInstallationTokenLifetime`. Verified it fails on the previous 55-minute value — *"outlives its 1h0m0s token by 25m0s"* — and passes now.

Full `internal/clients` suite green under `go test -race -count=2`.

## Not addressed

The cache is keyed on **ProviderConfig name only**, so a credentials rotation isn't noticed until the TTL lapses — up to a full TTL of calls against superseded credentials. Fixing that wants a fingerprint of the resolved credentials in the cache key, which changes what the fast path has to fetch; kept out of here deliberately. Happy to follow up if maintainers want it.

---

Signed-off-by via DCO on both commits. Happy to adjust naming/structure or split into two PRs to match maintainer preference.
