### PR TITLE
fix(config): stop child managed resources from wedging when the parent is gone

### DIFF
--- a/config/parent_deletion.go
+++ b/config/parent_deletion.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package config
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-github/v88/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Several terraform-provider-github resources violate the terraform-plugin-sdk
+// Read contract: when their parent object is gone they return an error instead of
+// clearing the ID and returning nil. upjet's SDK external client surfaces that as
+// an error from Observe rather than ResourceExists:false, so crossplane-runtime
+// never removes the delete finalizer and the child managed resource stays in
+// Terminating forever.
+//
+// The wrappers below turn a missing parent into the SDK's "gone" signal
+// (SetId("") + nil). Every other error -- 401/403/5xx, network -- is propagated
+// unchanged so a transient failure never orphans a live resource. Resources that
+// already clear the ID on a 404 are excluded, and every entry here should be
+// dropped as upstream fixes land. Verified against terraform-provider-github
+// v6.13.0.
+
+// parentDeletionWorkaroundResources are repository children exposing the legacy
+// Read field whose reads return a bare error on a parent-repository 404.
+//
+// Excluded because they already clear the ID themselves: github_branch_protection
+// (via its GraphQL "Could not resolve to a node with the global id" branch),
+// github_repository_collaborators, github_repository_custom_property,
+// github_repository_ruleset, github_branch_default and
+// github_app_installation_repository. github_actions_organization_permissions is
+// org-scoped, so repository deletion never wedges it.
+var parentDeletionWorkaroundResources = []string{
+	"github_issue_labels",
+	"github_repository_dependabot_security_updates",
+	"github_actions_repository_access_level",
+	"github_actions_repository_permissions",
+	"github_workflow_repository_permissions",
+}
+
+// teamParentDeletionWorkaroundResources are team children whose ReadContext
+// resolves the parent team by slug (getTeamID / lookupTeamID ->
+// Teams.GetTeamBySlug) and returns diag.FromErr on the lookup 404. Each handles a
+// 404 only later, past the point that wedges.
+//
+// Excluded because they already clear the ID on a 404: github_team (resolves by
+// numeric ID), github_emu_group_mapping and github_team_sync_group_mapping.
+// github_team_settings resolves the team over GraphQL, so there is no REST 404 to
+// match; a missing team is believed to come back as a null Team, inferred from the
+// resource code rather than confirmed against the live API.
+var teamParentDeletionWorkaroundResources = []string{
+	"github_team_repository",
+	"github_team_membership",
+	"github_team_members",
+}
+
+// commitLookupParentDeletionWorkaroundResources are resources that guard their
+// primary lookup but then make a second, unguarded one. github_repository_file is
+// the only one: its content lookup is guarded, but the commit lookup that follows
+// (Repositories.GetCommit when commit_sha is in state, otherwise getFileCommit)
+// ends in a bare diag.FromErr for both of its "gone" outcomes -- a 404, and an
+// exhausted commit list.
+var commitLookupParentDeletionWorkaroundResources = []string{
+	"github_repository_file",
+}
+
+// wrapReadForParentDeletion translates a typed GitHub 404 (parent repository gone)
+// into the SDK's "gone" signal. It runs before the SDK flattens the returned error
+// into a diagnostic, so the typed *github.ErrorResponse is still available to
+// errors.As.
+//
+// A 404 from the actions/*-permissions endpoints is an unambiguous "repo gone":
+// GitHub returns enabled:false payloads, not 404, when a feature is merely
+// disabled.
+// nolint:staticcheck // SA1019: the affected upstream resources define the
+// legacy schema.Resource.Read field (not ReadContext), and the SDK forbids
+// setting both, so the wrapper must operate on the deprecated ReadFunc.
+func wrapReadForParentDeletion(orig schema.ReadFunc) schema.ReadFunc {
+	return func(d *schema.ResourceData, meta interface{}) error {
+		err := orig(d, meta)
+		if err == nil {
+			return nil
+		}
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+}
+
+// isGitHubNotFoundDiag reports whether diags contains an HTTP 404 from the GitHub
+// API. ReadContext funcs return errors via diag.FromErr, which keeps only
+// err.Error() and discards the wrapped error, so the typed *github.ErrorResponse
+// is unavailable here and the rendered status has to be matched instead.
+//
+// Both anchors are load-bearing. (*github.ErrorResponse).Error() renders the
+// status either after ": " or at the start of the summary, and some upstream reads
+// interpolate a caller-supplied name into the message -- matching any
+// space-delimited "404" would read a path like "docs/error 404 page.html" as an
+// HTTP 404 and drop the delete finalizer on a live resource.
+func isGitHubNotFoundDiag(diags diag.Diagnostics) bool {
+	for _, d := range diags {
+		if d.Severity != diag.Error {
+			continue
+		}
+		if strings.Contains(d.Summary, ": 404 ") || strings.HasPrefix(d.Summary, "404 ") {
+			return true
+		}
+	}
+	return false
+}
+
+// wrapReadContextForParentDeletion translates a GitHub 404 surfaced as an error
+// diagnostic (parent team gone) into the SDK's "gone" signal.
+//
+// GitHub returns 404, not 403, for objects a token cannot see, so a permissions or
+// scope blip is indistinguishable from a genuine deletion here and is treated as
+// gone.
+func wrapReadContextForParentDeletion(orig schema.ReadContextFunc) schema.ReadContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		diags := orig(ctx, d, meta)
+		if isGitHubNotFoundDiag(diags) {
+			d.SetId("")
+			return nil
+		}
+		return diags
+	}
+}
+
+// Mirrors getFileCommit's exhaustion error, which upstream renders as
+// fmt.Errorf("cannot find file %s in repo %s/%s", file, owner, repo).
+const (
+	fileCommitNotFoundPrefix    = "cannot find file "
+	fileCommitNotFoundSeparator = " in repo "
+)
+
+// isFileCommitNotFoundDiag reports whether diags says no commit reachable from the
+// ref still contains the file. That is a "gone" signal, but it carries no HTTP
+// status, so isGitHubNotFoundDiag cannot see it.
+func isFileCommitNotFoundDiag(diags diag.Diagnostics) bool {
+	for _, d := range diags {
+		if d.Severity != diag.Error {
+			continue
+		}
+		if rest, ok := afterFileCommitNotFoundPrefix(d.Summary); ok &&
+			strings.Contains(rest, fileCommitNotFoundSeparator) {
+			return true
+		}
+	}
+	return false
+}
+
+// afterFileCommitNotFoundPrefix returns what follows the exhaustion-error prefix,
+// allowing for a ": " wrapping boundary the way isGitHubNotFoundDiag does.
+//
+// The prefix must open the message rather than appear anywhere in it: the path,
+// owner and repo are all interpolated into that error, so a substring match would
+// read an unrelated failure that merely quotes a user-supplied name as "gone".
+func afterFileCommitNotFoundPrefix(summary string) (string, bool) {
+	if i := strings.Index(summary, ": "+fileCommitNotFoundPrefix); i >= 0 {
+		summary = summary[i+len(": "):]
+	}
+	return strings.CutPrefix(summary, fileCommitNotFoundPrefix)
+}
+
+// wrapReadContextForCommitLookupDeletion turns both ways the commit lookup reports
+// a missing resource -- a GitHub 404, and an exhausted commit list -- into the
+// SDK's "gone" signal.
+//
+// The string match is a bridge until integrations/terraform-provider-github#3587
+// lands a sentinel error matchable with errors.Is; drop this wrapper,
+// isFileCommitNotFoundDiag and the list it serves once the pinned version carries
+// it.
+func wrapReadContextForCommitLookupDeletion(orig schema.ReadContextFunc) schema.ReadContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		diags := orig(ctx, d, meta)
+		if isGitHubNotFoundDiag(diags) || isFileCommitNotFoundDiag(diags) {
+			d.SetId("")
+			return nil
+		}
+		return diags
+	}
+}
+
+// withParentDeletionWorkaround wraps the affected resources' read functions on the
+// in-memory provider. It mutates and returns the same provider so it can be used
+// inline at the ujconfig.WithTerraformProvider call site. A resource the pinned
+// provider no longer defines, or one that has moved off the field its wrapper
+// replaces, is skipped.
+func withParentDeletionWorkaround(p *schema.Provider) *schema.Provider {
+	wrapRepositoryChildReads(p)
+	wrapTeamChildReads(p)
+	wrapCommitLookupReads(p)
+	return p
+}
+
+func wrapRepositoryChildReads(p *schema.Provider) {
+	for _, name := range parentDeletionWorkaroundResources {
+		r, ok := p.ResourcesMap[name]
+		if !ok || r == nil || r.Read == nil { //nolint:staticcheck // SA1019: intentionally wrapping the legacy Read field these resources define.
+			continue
+		}
+		r.Read = wrapReadForParentDeletion(r.Read) //nolint:staticcheck // SA1019: see above; the SDK forbids setting ReadContext alongside Read.
+	}
+}
+
+func wrapTeamChildReads(p *schema.Provider) {
+	for _, name := range teamParentDeletionWorkaroundResources {
+		r, ok := p.ResourcesMap[name]
+		if !ok || r == nil || r.ReadContext == nil {
+			continue
+		}
+		r.ReadContext = wrapReadContextForParentDeletion(r.ReadContext)
+	}
+}
+
+func wrapCommitLookupReads(p *schema.Provider) {
+	for _, name := range commitLookupParentDeletionWorkaroundResources {
+		r, ok := p.ResourcesMap[name]
+		if !ok || r == nil || r.ReadContext == nil {
+			continue
+		}
+		r.ReadContext = wrapReadContextForCommitLookupDeletion(r.ReadContext)
+	}
+}

--- a/config/parent_deletion.go
+++ b/config/parent_deletion.go
@@ -72,6 +72,64 @@ var commitLookupParentDeletionWorkaroundResources = []string{
 	"github_repository_file",
 }
 
+// branchNotProtectedWorkaroundResources lists resources that wedge on their own
+// deletion rather than a parent's. Despite living in this file, this is not a
+// parent-404 family at all: nothing about the repository, branch or any parent
+// is missing. The resource's own Read cannot recognise the resource as gone
+// immediately after its own successful Delete.
+//
+// github_branch_protection_v3 is the only member. Verified against
+// terraform-provider-github v6.13.0 and go-github v88.0.0:
+//
+//   - GitHub answers GET .../branches/<branch>/protection with 404 and the
+//     message "Branch not protected" once protection is removed.
+//   - go-github's GetBranchProtection detects exactly that message
+//     (isBranchNotProtected -> errorResponse.Message == "Branch not protected")
+//     and *substitutes* the bare sentinel github.ErrBranchNotProtected -- a
+//     plain errors.New with no Response and no wrapping -- discarding the
+//     *github.ErrorResponse.
+//   - resourceGithubBranchProtectionV3Read then does
+//     errors.As(err, &ghErr) on *github.ErrorResponse. The sentinel is not one,
+//     so errors.As fails, its http.StatusNotFound arm that would SetId("") is
+//     unreachable, and it falls through to `return err`.
+//
+// So after the provider's own Delete succeeds, the confirming Observe hard-errors
+// forever. crossplane-runtime can never conclude the external resource is absent,
+// never removes the delete finalizer, and the MR stays in Terminating
+// permanently. This is an upstream Read-contract bug. The upstream fix would be
+// an added errors.Is(err, github.ErrBranchNotProtected) check alongside the
+// existing errors.As. No issue or PR has been filed as of this commit -- unlike
+// commitLookupParentDeletionWorkaroundResources above, which cites a concrete
+// upstream issue, this is a recommendation with nothing tracking it yet.
+//
+// Only Read reaches the sentinel. requireSignedCommitsRead calls
+// GetSignaturesProtectedBranch, which can also return it, but that function
+// swallows every error (`return nil //nolint:nilerr`), so it never propagates.
+// GetRequiredStatusChecks and ListRequiredStatusChecksContexts are the other two
+// go-github functions that substitute the sentinel; no terraform-provider-github
+// resource calls either at this version.
+//
+// Deliberately NOT handled here, and why:
+//   - The parent-repository-gone case for this same resource. When the repository
+//     is gone, GitHub's message is "Not Found", not "Branch not protected", so
+//     isBranchNotProtected does not match, the *github.ErrorResponse survives,
+//     and upstream's own http.StatusNotFound arm clears the ID correctly. Note
+//     that this rests on GitHub returning "Not Found" for an absent repository:
+//     that is inferred from the API's documented behaviour and from
+//     isBranchNotProtected's exact-message match, NOT verified against a live
+//     deleted repository. A branch deleted while the repository survives is
+//     believed to behave the same way ("Branch not found"), likewise unverified.
+//     If either assumption is wrong, the symptom is a wedge on parent deletion,
+//     not a dropped finalizer on a live resource.
+//   - github_branch_protection (the non-v3, GraphQL resource). It is already
+//     excluded from parentDeletionWorkaroundResources above, but for a different
+//     question (its GraphQL repo-gone handling) -- do not look there for sentinel
+//     reasoning. It does not call this REST endpoint at all, so it can never see
+//     this sentinel.
+var branchNotProtectedWorkaroundResources = []string{
+	"github_branch_protection_v3",
+}
+
 // wrapReadForParentDeletion translates a typed GitHub 404 (parent repository gone)
 // into the SDK's "gone" signal. It runs before the SDK flattens the returned error
 // into a diagnostic, so the typed *github.ErrorResponse is still available to
@@ -192,15 +250,71 @@ func wrapReadContextForCommitLookupDeletion(orig schema.ReadContextFunc) schema.
 	}
 }
 
+// wrapReadForBranchNotProtected wraps an old-style schema.ReadFunc so that
+// go-github's github.ErrBranchNotProtected sentinel is translated into the SDK's
+// "resource no longer exists" signal (SetId("") + nil error) instead of a hard
+// error. Every other error is propagated unchanged.
+//
+// This wraps the legacy Read field, so it runs before the SDK flattens the Go
+// error into a diagnostic and can match the error *identity* with errors.Is.
+// Match the sentinel only -- never its message. github.ErrBranchNotProtected is
+// a bare errors.New, so a different error value carrying the identical text is
+// not this condition, and a string match would treat it as one.
+//
+// No http.StatusNotFound arm here, deliberately. go-github only substitutes the
+// sentinel when the repository and branch both exist and protection is absent, so
+// a genuine 404 (repository or branch gone) still arrives as a
+// *github.ErrorResponse and upstream's own StatusNotFound arm already clears the
+// ID. Adding a 404 arm would be dead code.
+//
+// Caveats (honest scope):
+//
+//   - Unlike wrapReadContextForParentDeletion, this wrapper does NOT carry the
+//     "GitHub returns 404 rather than 403 for resources a token cannot see" risk.
+//     An unreadable repository yields message "Not Found", never "Branch not
+//     protected", so a permissions blip cannot reach this sentinel and cannot
+//     drop the delete finalizer on a live resource. The sentinel means protection
+//     is genuinely absent.
+//   - The create-retry consequence also inverts relative to the other families.
+//     If protection is removed out-of-band, Observe now reports
+//     ResourceExists:false and crossplane-runtime calls Create, which re-applies
+//     protection and succeeds, because the branch still exists. That is drift
+//     correction, not the create-retry loop the parent-404 families produce
+//     (there the parent is gone, so Create cannot succeed).
+//   - It does not fix the underlying upstream bug: `terraform plan` against the
+//     unwrapped provider still errors. Only this provider's Read path is repaired.
+//
+// nolint:staticcheck // SA1019: github_branch_protection_v3 defines the legacy
+// schema.Resource.Read field (not ReadContext), and the SDK forbids setting both,
+// so the wrapper must operate on the deprecated ReadFunc.
+func wrapReadForBranchNotProtected(orig schema.ReadFunc) schema.ReadFunc {
+	return func(d *schema.ResourceData, meta interface{}) error {
+		err := orig(d, meta)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, github.ErrBranchNotProtected) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+}
+
 // withParentDeletionWorkaround wraps the affected resources' read functions on the
 // in-memory provider. It mutates and returns the same provider so it can be used
 // inline at the ujconfig.WithTerraformProvider call site. A resource the pinned
 // provider no longer defines, or one that has moved off the field its wrapper
 // replaces, is skipped.
+//
+// The fourth loop is not a parent-deletion case despite the name: it lets
+// github_branch_protection_v3 recognise its own successful deletion. See
+// branchNotProtectedWorkaroundResources.
 func withParentDeletionWorkaround(p *schema.Provider) *schema.Provider {
 	wrapRepositoryChildReads(p)
 	wrapTeamChildReads(p)
 	wrapCommitLookupReads(p)
+	wrapBranchNotProtectedReads(p)
 	return p
 }
 
@@ -231,5 +345,15 @@ func wrapCommitLookupReads(p *schema.Provider) {
 			continue
 		}
 		r.ReadContext = wrapReadContextForCommitLookupDeletion(r.ReadContext)
+	}
+}
+
+func wrapBranchNotProtectedReads(p *schema.Provider) {
+	for _, name := range branchNotProtectedWorkaroundResources {
+		r, ok := p.ResourcesMap[name]
+		if !ok || r == nil || r.Read == nil { //nolint:staticcheck // SA1019: intentionally wrapping the legacy Read field this resource defines.
+			continue
+		}
+		r.Read = wrapReadForBranchNotProtected(r.Read) //nolint:staticcheck // SA1019: see above; the SDK forbids setting ReadContext alongside Read.
 	}
 }

--- a/config/parent_deletion_test.go
+++ b/config/parent_deletion_test.go
@@ -1,0 +1,498 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v88/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	tpg "github.com/integrations/terraform-provider-github/v6/github"
+)
+
+// The wrappers skip unknown keys, so a typo or a rename would be a silent no-op
+// with no build or test failure. Assert every listed resource exists in the real
+// provider and exposes the field its wrapper replaces.
+func TestParentDeletionWorkaroundResourcesAreWired(t *testing.T) {
+	p := tpg.NewProvider("dev", "none")()
+	for _, name := range parentDeletionWorkaroundResources {
+		r, ok := p.ResourcesMap[name]
+		if !ok {
+			t.Errorf("%q is not a registered terraform-provider-github resource (silently skipped — typo or renamed key?)", name)
+			continue
+		}
+		if r.Read == nil { //nolint:staticcheck // SA1019: verifying the legacy Read field the wrapper depends on is present.
+			t.Errorf("%q has no legacy Read func; withParentDeletionWorkaround would silently skip it", name)
+		}
+	}
+}
+
+// A typed 404 becomes the "gone" signal; every other error propagates unchanged.
+func TestWrapReadForParentDeletion(t *testing.T) {
+	const startingID = "some-owner/some-repo"
+
+	notFound := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+		Message:  "Not Found",
+	}
+	forbidden := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusForbidden},
+		Message:  "Forbidden",
+	}
+	serverErr := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusInternalServerError},
+		Message:  "Server Error",
+	}
+	genericErr := errors.New("dial tcp: connection refused")
+
+	cases := map[string]struct {
+		underlyingErr error
+		wantErr       error
+		wantClearedID bool
+	}{
+		"typed 404 clears ID and returns nil": {
+			underlyingErr: notFound,
+			wantErr:       nil,
+			wantClearedID: true,
+		},
+		"typed 403 is propagated and keeps ID": {
+			underlyingErr: forbidden,
+			wantErr:       forbidden,
+			wantClearedID: false,
+		},
+		"typed 500 is propagated and keeps ID": {
+			underlyingErr: serverErr,
+			wantErr:       serverErr,
+			wantClearedID: false,
+		},
+		"non-github error is propagated and keeps ID": {
+			underlyingErr: genericErr,
+			wantErr:       genericErr,
+			wantClearedID: false,
+		},
+		"nil error passes through and keeps ID": {
+			underlyingErr: nil,
+			wantErr:       nil,
+			wantClearedID: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+			d.SetId(startingID)
+
+			wrapped := wrapReadForParentDeletion(func(_ *schema.ResourceData, _ interface{}) error {
+				return tc.underlyingErr
+			})
+
+			gotErr := wrapped(d, nil)
+
+			if !errors.Is(gotErr, tc.wantErr) {
+				t.Fatalf("error mismatch: got %v, want %v", gotErr, tc.wantErr)
+			}
+			if tc.wantClearedID {
+				if d.Id() != "" {
+					t.Fatalf("expected ID to be cleared, got %q", d.Id())
+				}
+			} else {
+				if d.Id() != startingID {
+					t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+				}
+			}
+		})
+	}
+}
+
+// Still detected if an upstream Read starts wrapping rather than returning the
+// raw client error.
+func TestWrapReadForParentDeletion_WrappedTyped404(t *testing.T) {
+	notFound := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+		Message:  "Not Found",
+	}
+	d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+	d.SetId("some-owner/some-repo")
+
+	wrapped := wrapReadForParentDeletion(func(_ *schema.ResourceData, _ interface{}) error {
+		return fmt.Errorf("reading issue labels: %w", notFound)
+	})
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected wrapped typed 404 to be treated as gone (nil error), got %v", err)
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected ID to be cleared for wrapped typed 404, got %q", d.Id())
+	}
+}
+
+// ghErrDiag renders an error the way the upstream ReadContext funcs do. The
+// Request is attached so the summary carries the "<method> <url>: <status>" form.
+func ghErrDiag(status int, message string) diag.Diagnostics {
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/orgs/o/teams/some-team", nil)
+	return diag.FromErr(&github.ErrorResponse{
+		Response: &http.Response{StatusCode: status, Request: req},
+		Message:  message,
+	})
+}
+
+// A 404 surfaced as an error diagnostic becomes the "gone" signal; every other
+// error propagates unchanged.
+func TestWrapReadContextForParentDeletion(t *testing.T) {
+	const startingID = "some-team:some-repo"
+
+	cases := map[string]struct {
+		diags         diag.Diagnostics
+		wantErr       bool
+		wantClearedID bool
+	}{
+		"404 clears ID and returns no error": {
+			diags:         ghErrDiag(http.StatusNotFound, "Not Found"),
+			wantErr:       false,
+			wantClearedID: true,
+		},
+		"403 is propagated and keeps ID": {
+			diags:         ghErrDiag(http.StatusForbidden, "Forbidden"),
+			wantErr:       true,
+			wantClearedID: false,
+		},
+		"500 is propagated and keeps ID": {
+			diags:         ghErrDiag(http.StatusInternalServerError, "Server Error"),
+			wantErr:       true,
+			wantClearedID: false,
+		},
+		"non-github error is propagated and keeps ID": {
+			diags:         diag.FromErr(errors.New("dial tcp: connection refused")),
+			wantErr:       true,
+			wantClearedID: false,
+		},
+		"no error passes through and keeps ID": {
+			diags:         nil,
+			wantErr:       false,
+			wantClearedID: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+			d.SetId(startingID)
+
+			wrapped := wrapReadContextForParentDeletion(func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+				return tc.diags
+			})
+
+			gotDiags := wrapped(context.Background(), d, nil)
+
+			if gotDiags.HasError() != tc.wantErr {
+				t.Fatalf("HasError() = %v, want %v (diags: %v)", gotDiags.HasError(), tc.wantErr, gotDiags)
+			}
+			// When propagating, the diagnostics must be returned unchanged (not
+			// swapped for a different error).
+			if tc.wantErr {
+				if len(gotDiags) != len(tc.diags) || (len(gotDiags) > 0 && gotDiags[0].Summary != tc.diags[0].Summary) {
+					t.Fatalf("expected diags propagated unchanged, got %v want %v", gotDiags, tc.diags)
+				}
+			}
+			if tc.wantClearedID {
+				if d.Id() != "" {
+					t.Fatalf("expected ID to be cleared, got %q", d.Id())
+				}
+			} else {
+				if d.Id() != startingID {
+					t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+				}
+			}
+		})
+	}
+}
+
+// Wiring guard for the team list, as above.
+func TestTeamParentDeletionWorkaroundResourcesAreWired(t *testing.T) {
+	p := tpg.NewProvider("dev", "none")()
+	for _, name := range teamParentDeletionWorkaroundResources {
+		r, ok := p.ResourcesMap[name]
+		if !ok {
+			t.Errorf("%q is not a registered terraform-provider-github resource (silently skipped — typo or renamed key?)", name)
+			continue
+		}
+		if r.ReadContext == nil {
+			t.Errorf("%q has no ReadContext func; withParentDeletionWorkaround would silently skip it", name)
+		}
+	}
+}
+
+// Wiring guard for the commit-lookup list, as above.
+func TestCommitLookupParentDeletionWorkaroundResourcesAreWired(t *testing.T) {
+	p := tpg.NewProvider("dev", "none")()
+	for _, name := range commitLookupParentDeletionWorkaroundResources {
+		r, ok := p.ResourcesMap[name]
+		if !ok {
+			t.Errorf("%q is not a registered terraform-provider-github resource (silently skipped — typo or renamed key?)", name)
+			continue
+		}
+		if r.ReadContext == nil {
+			t.Errorf("%q has no ReadContext func; withParentDeletionWorkaround would silently skip it", name)
+		}
+	}
+}
+
+// The wiring guard only proves the resource is present, so compare the function
+// pointer to prove it is actually replaced.
+func TestWithParentDeletionWorkaroundReplacesCommitLookupReadContext(t *testing.T) {
+	p := tpg.NewProvider("dev", "none")()
+
+	before := map[string]string{}
+	for _, name := range commitLookupParentDeletionWorkaroundResources {
+		before[name] = fmt.Sprintf("%p", p.ResourcesMap[name].ReadContext)
+	}
+
+	withParentDeletionWorkaround(p)
+
+	for _, name := range commitLookupParentDeletionWorkaroundResources {
+		after := fmt.Sprintf("%p", p.ResourcesMap[name].ReadContext)
+		if after == before[name] {
+			t.Errorf("%q ReadContext was not wrapped (pointer unchanged: %s)", name, after)
+		}
+	}
+}
+
+// Both go-github renderings must be recognised: with a request attached
+// ("<method> <url>: 404 ...") and without ("404 ...").
+func TestWrapReadContextForParentDeletion_BothRenderedForms(t *testing.T) {
+	cases := map[string]diag.Diagnostics{
+		"with request":    ghErrDiag(http.StatusNotFound, "Not Found"),
+		"without request": diag.FromErr(&github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}, Message: "Not Found"}),
+	}
+
+	for name, diags := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+			d.SetId("some-repo/some-file:main")
+
+			wrapped := wrapReadContextForParentDeletion(func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+				return diags
+			})
+			got := wrapped(context.Background(), d, nil)
+
+			if got.HasError() {
+				t.Fatalf("expected 404 to be treated as gone, got %v", got)
+			}
+			if d.Id() != "" {
+				t.Fatalf("expected ID to be cleared, got %q", d.Id())
+			}
+		})
+	}
+}
+
+// A file path containing a bare "404" is not an HTTP status. Relaxing the anchor
+// in isGitHubNotFoundDiag to any space-delimited "404" fails this test.
+func TestWrapReadContextForParentDeletion_PathContaining404IsNotGone(t *testing.T) {
+	const startingID = "some-repo/docs/error 404 page.html:main"
+
+	cases := map[string]string{
+		"cannot find file with 404 in the path": "cannot find file docs/error 404 page.html in repo some-owner/some-repo",
+		"bare 404 token mid-message":            "unexpected failure reading 404 handler config",
+	}
+
+	for name, summary := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+			d.SetId(startingID)
+
+			in := diag.FromErr(errors.New(summary))
+			wrapped := wrapReadContextForParentDeletion(func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+				return in
+			})
+			got := wrapped(context.Background(), d, nil)
+
+			if !got.HasError() {
+				t.Fatalf("expected error to propagate, got %v", got)
+			}
+			if len(got) != len(in) || got[0].Summary != in[0].Summary {
+				t.Fatalf("expected diags propagated unchanged, got %v want %v", got, in)
+			}
+			if d.Id() != startingID {
+				t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+			}
+		})
+	}
+}
+
+// An exhausted commit list carries no HTTP status, so it must be treated as gone
+// alongside a 404.
+func TestWrapReadContextForCommitLookupDeletion(t *testing.T) {
+	const startingID = "some-repo/docs/index.md:main"
+
+	exhausted := diag.FromErr(errors.New("cannot find file docs/index.md in repo some-owner/some-repo"))
+	wrappedExhausted := diag.FromErr(fmt.Errorf("looking for commit: %w", errors.New("cannot find file docs/index.md in repo some-owner/some-repo")))
+
+	cases := map[string]struct {
+		diags         diag.Diagnostics
+		wantGone      bool
+		wantPropagate bool
+	}{
+		"commit-list exhaustion clears ID": {
+			diags:    exhausted,
+			wantGone: true,
+		},
+		"wrapped commit-list exhaustion clears ID": {
+			diags:    wrappedExhausted,
+			wantGone: true,
+		},
+		"404 still clears ID": {
+			diags:    ghErrDiag(http.StatusNotFound, "Not Found"),
+			wantGone: true,
+		},
+		"403 is propagated and keeps ID": {
+			diags:         ghErrDiag(http.StatusForbidden, "Forbidden"),
+			wantPropagate: true,
+		},
+		"500 is propagated and keeps ID": {
+			diags:         ghErrDiag(http.StatusInternalServerError, "Server Error"),
+			wantPropagate: true,
+		},
+		"network error is propagated and keeps ID": {
+			diags:         diag.FromErr(errors.New("dial tcp: connection refused")),
+			wantPropagate: true,
+		},
+		"no error passes through and keeps ID": {
+			diags: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+			d.SetId(startingID)
+
+			wrapped := wrapReadContextForCommitLookupDeletion(func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+				return tc.diags
+			})
+			got := wrapped(context.Background(), d, nil)
+
+			if tc.wantGone {
+				if got.HasError() {
+					t.Fatalf("expected gone (no diags), got %v", got)
+				}
+				if d.Id() != "" {
+					t.Fatalf("expected ID to be cleared, got %q", d.Id())
+				}
+				return
+			}
+			if tc.wantPropagate {
+				if !got.HasError() {
+					t.Fatalf("expected error to propagate, got %v", got)
+				}
+				if len(got) != len(tc.diags) || got[0].Summary != tc.diags[0].Summary {
+					t.Fatalf("expected diags propagated unchanged, got %v want %v", got, tc.diags)
+				}
+			}
+			if d.Id() != startingID {
+				t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+			}
+		})
+	}
+}
+
+// These quote the exhaustion phrase without being the exhaustion error. Relaxing
+// afterFileCommitNotFoundPrefix to a plain substring match fails all three.
+func TestWrapReadContextForCommitLookupDeletion_NearMissesPropagate(t *testing.T) {
+	const startingID = "some-repo/docs/index.md:main"
+
+	cases := map[string]string{
+		// Phrase mid-summary, so the opening anchor rejects it.
+		"phrase mid-summary from a user-supplied name": "branch cannot find file x in repo y/z not found in some-owner/some-repo or repository is not readable",
+		// Prefix without the separator that follows it upstream.
+		"prefix without the in-repo separator": "cannot find file docs/index.md",
+		// Phrase quoted inside a genuine API failure.
+		"phrase inside a 403 summary": "GET https://api.github.com/repos/o/r/commits: 403 cannot find file x in repo y/z []",
+	}
+
+	for name, summary := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+			d.SetId(startingID)
+
+			in := diag.FromErr(errors.New(summary))
+			wrapped := wrapReadContextForCommitLookupDeletion(func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+				return in
+			})
+			got := wrapped(context.Background(), d, nil)
+
+			if !got.HasError() {
+				t.Fatalf("expected error to propagate, got %v", got)
+			}
+			if len(got) != len(in) || got[0].Summary != in[0].Summary {
+				t.Fatalf("expected diags propagated unchanged, got %v want %v", got, in)
+			}
+			if d.Id() != startingID {
+				t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+			}
+		})
+	}
+}
+
+// Deliberately asserted in the positive direction: a file whose own path contains
+// the phrase still renders as a genuine exhaustion error when it is really gone.
+func TestWrapReadContextForCommitLookupDeletion_PathContainingPhraseIsGone(t *testing.T) {
+	d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+	d.SetId("some-repo/cannot find file x in repo y/z:main")
+
+	in := diag.FromErr(errors.New("cannot find file cannot find file x in repo y/z in repo some-owner/some-repo"))
+	wrapped := wrapReadContextForCommitLookupDeletion(func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+		return in
+	})
+	got := wrapped(context.Background(), d, nil)
+
+	if got.HasError() {
+		t.Fatalf("expected gone (no diags), got %v", got)
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected ID to be cleared, got %q", d.Id())
+	}
+}
+
+// Keeping the two predicates separate bounds each workaround to the resources that
+// need it, so the team wrapper must not treat commit-list exhaustion as gone.
+func TestWrapReadContextForParentDeletion_IgnoresFileCommitExhaustion(t *testing.T) {
+	const startingID = "some-team:some-repo"
+
+	d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+	d.SetId(startingID)
+
+	in := diag.FromErr(errors.New("cannot find file docs/index.md in repo some-owner/some-repo"))
+	wrapped := wrapReadContextForParentDeletion(func(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+		return in
+	})
+	got := wrapped(context.Background(), d, nil)
+
+	if !got.HasError() {
+		t.Fatalf("expected error to propagate through the team wrapper, got %v", got)
+	}
+	if d.Id() != startingID {
+		t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+	}
+}
+
+// As above, for the team list.
+func TestWithParentDeletionWorkaroundReplacesTeamReadContext(t *testing.T) {
+	p := tpg.NewProvider("dev", "none")()
+
+	before := map[string]string{}
+	for _, name := range teamParentDeletionWorkaroundResources {
+		before[name] = fmt.Sprintf("%p", p.ResourcesMap[name].ReadContext)
+	}
+
+	withParentDeletionWorkaround(p)
+
+	for _, name := range teamParentDeletionWorkaroundResources {
+		after := fmt.Sprintf("%p", p.ResourcesMap[name].ReadContext)
+		if after == before[name] {
+			t.Errorf("%q ReadContext was not wrapped (pointer unchanged: %s)", name, after)
+		}
+	}
+}

--- a/config/parent_deletion_test.go
+++ b/config/parent_deletion_test.go
@@ -496,3 +496,191 @@ func TestWithParentDeletionWorkaroundReplacesTeamReadContext(t *testing.T) {
 		}
 	}
 }
+
+func TestBranchNotProtectedWorkaroundResourcesAreWired(t *testing.T) {
+	p := tpg.NewProvider("dev", "none")()
+	for _, name := range branchNotProtectedWorkaroundResources {
+		r, ok := p.ResourcesMap[name]
+		if !ok {
+			t.Errorf("%q is not a registered terraform-provider-github resource (silently skipped — typo or renamed key?)", name)
+			continue
+		}
+		if r.Read == nil { //nolint:staticcheck // SA1019: verifying the legacy Read field the wrapper depends on is present.
+			t.Errorf("%q has no legacy Read func; withParentDeletionWorkaround would silently skip it (migrated to ReadContext upstream?)", name)
+		}
+	}
+}
+
+// wrapReadForBranchNotProtected must translate go-github's
+// ErrBranchNotProtected sentinel -- which upstream's errors.As on
+// *github.ErrorResponse cannot see, leaving its SetId("") arm unreachable -- into
+// the SDK "gone" signal, while propagating every other error unchanged.
+//
+// The typed 404 case is asserted as *propagated*, not translated: this wrapper
+// deliberately has no StatusNotFound arm, because a real 404 keeps its
+// *github.ErrorResponse and upstream clears the ID itself.
+func TestWrapReadForBranchNotProtected(t *testing.T) {
+	const startingID = "some-repo:main"
+
+	notFound := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+		Message:  "Not Found",
+	}
+	forbidden := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusForbidden},
+		Message:  "Forbidden",
+	}
+	serverErr := &github.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusInternalServerError},
+		Message:  "Server Error",
+	}
+	genericErr := errors.New("dial tcp: connection refused")
+
+	cases := map[string]struct {
+		underlyingErr error
+		wantErr       error
+		wantClearedID bool
+	}{
+		"ErrBranchNotProtected sentinel clears ID and returns nil": {
+			underlyingErr: github.ErrBranchNotProtected,
+			wantErr:       nil,
+			wantClearedID: true,
+		},
+		"typed 404 is propagated and keeps ID (upstream clears it itself)": {
+			underlyingErr: notFound,
+			wantErr:       notFound,
+			wantClearedID: false,
+		},
+		"typed 403 is propagated and keeps ID": {
+			underlyingErr: forbidden,
+			wantErr:       forbidden,
+			wantClearedID: false,
+		},
+		"typed 500 is propagated and keeps ID": {
+			underlyingErr: serverErr,
+			wantErr:       serverErr,
+			wantClearedID: false,
+		},
+		"non-github error is propagated and keeps ID": {
+			underlyingErr: genericErr,
+			wantErr:       genericErr,
+			wantClearedID: false,
+		},
+		"nil error passes through and keeps ID": {
+			underlyingErr: nil,
+			wantErr:       nil,
+			wantClearedID: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+			d.SetId(startingID)
+
+			wrapped := wrapReadForBranchNotProtected(func(_ *schema.ResourceData, _ interface{}) error {
+				return tc.underlyingErr
+			})
+
+			gotErr := wrapped(d, nil)
+
+			if !errors.Is(gotErr, tc.wantErr) {
+				t.Fatalf("error mismatch: got %v, want %v", gotErr, tc.wantErr)
+			}
+			if tc.wantClearedID {
+				if d.Id() != "" {
+					t.Fatalf("expected ID to be cleared, got %q", d.Id())
+				}
+			} else {
+				if d.Id() != startingID {
+					t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+				}
+			}
+		})
+	}
+}
+
+// The sentinel wrapped in a chain (fmt.Errorf("...: %w", ...)) must still be
+// detected, since errors.Is walks the chain. Upstream returns it bare today; this
+// guards against a regression if it starts annotating the error.
+func TestWrapReadForBranchNotProtected_WrappedSentinel(t *testing.T) {
+	d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+	d.SetId("some-repo:main")
+
+	wrapped := wrapReadForBranchNotProtected(func(_ *schema.ResourceData, _ interface{}) error {
+		return fmt.Errorf("reading branch protection: %w", github.ErrBranchNotProtected)
+	})
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected wrapped sentinel to be treated as gone (nil error), got %v", err)
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected ID to be cleared for wrapped sentinel, got %q", d.Id())
+	}
+}
+
+// The near-miss for an identity match is a *different* error value carrying the
+// byte-identical message. github.ErrBranchNotProtected is a bare errors.New, so
+// only its identity means "protection is absent"; an unrelated error that happens
+// to render the same text does not, and treating it as gone would drop the delete
+// finalizer on a live resource.
+//
+// This is the test that fails if anyone ever "simplifies" the wrapper to
+// strings.Contains(err.Error(), "branch is not protected") -- a real temptation
+// here, since the other three wrappers in this file are string matchers.
+func TestWrapReadForBranchNotProtected_IdenticalMessageIsNotTheSentinel(t *testing.T) {
+	const startingID = "some-repo:main"
+
+	// Same text as github.ErrBranchNotProtected, different error value.
+	impostor := errors.New("branch is not protected")
+
+	cases := map[string]error{
+		"distinct error with identical message": impostor,
+		"distinct error wrapped in a chain":     fmt.Errorf("reading branch protection: %w", impostor),
+		"message embedded in a larger error":    errors.New("upstream says branch is not protected, retrying"),
+	}
+
+	for name, underlying := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := (&schema.Resource{Schema: map[string]*schema.Schema{}}).TestResourceData()
+			d.SetId(startingID)
+
+			wrapped := wrapReadForBranchNotProtected(func(_ *schema.ResourceData, _ interface{}) error {
+				return underlying
+			})
+
+			gotErr := wrapped(d, nil)
+			if gotErr == nil {
+				t.Fatalf("expected %v to propagate, but it was treated as gone", underlying)
+			}
+			if gotErr.Error() != underlying.Error() {
+				t.Fatalf("error was altered: got %q, want %q", gotErr, underlying)
+			}
+			if d.Id() != startingID {
+				t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+			}
+		})
+	}
+}
+
+// TestWithParentDeletionWorkaroundReplacesBranchNotProtectedRead asserts the
+// composition: withParentDeletionWorkaround must actually replace the resource's
+// legacy Read pointer, not merely leave it wired. Comparing the pointer
+// before/after catches a missing or misordered loop that the wiring test above
+// would not.
+func TestWithParentDeletionWorkaroundReplacesBranchNotProtectedRead(t *testing.T) {
+	p := tpg.NewProvider("dev", "none")()
+
+	before := map[string]string{}
+	for _, name := range branchNotProtectedWorkaroundResources {
+		before[name] = fmt.Sprintf("%p", p.ResourcesMap[name].Read) //nolint:staticcheck // SA1019: the wrapper operates on the legacy Read field.
+	}
+
+	withParentDeletionWorkaround(p)
+
+	for _, name := range branchNotProtectedWorkaroundResources {
+		after := fmt.Sprintf("%p", p.ResourcesMap[name].Read) //nolint:staticcheck // SA1019: see above.
+		if after == before[name] {
+			t.Errorf("%q Read was not wrapped (pointer unchanged: %s)", name, after)
+		}
+	}
+}

--- a/config/provider_cluster.go
+++ b/config/provider_cluster.go
@@ -62,7 +62,7 @@ func GetProvider(ctx context.Context) (*ujconfig.Provider, error) {
 		ujconfig.WithTerraformPluginSDKIncludeList(resourceList(terraformPluginSDKExternalNameConfigs)),
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithReferenceInjectors([]ujconfig.ReferenceInjector{reference.NewInjector(modulePath)}),
-		ujconfig.WithTerraformProvider(github.NewProvider("dev", "none")()),
+		ujconfig.WithTerraformProvider(withParentDeletionWorkaround(github.NewProvider("dev", "none")())),
 		ujconfig.WithDefaultResourceOptions(
 			resourceConfigurator(),
 		))

--- a/config/provider_namespaced.go
+++ b/config/provider_namespaced.go
@@ -62,7 +62,7 @@ func GetProviderNamespaced(ctx context.Context) (*ujconfig.Provider, error) {
 		ujconfig.WithTerraformPluginSDKIncludeList(resourceList(terraformPluginSDKExternalNameConfigs)),
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithReferenceInjectors([]ujconfig.ReferenceInjector{reference.NewInjector(modulePath)}),
-		ujconfig.WithTerraformProvider(github.NewProvider("dev", "none")()),
+		ujconfig.WithTerraformProvider(withParentDeletionWorkaround(github.NewProvider("dev", "none")())),
 		ujconfig.WithDefaultResourceOptions(
 			resourceConfigurator(),
 		))

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/crossplane/crossplane-runtime/v2 v2.1.0
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
 	github.com/crossplane/upjet/v2 v2.2.0
+	github.com/google/go-github/v88 v88.0.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/integrations/terraform-provider-github/v6 v6.13.0
 	github.com/pkg/errors v0.9.1
@@ -57,7 +58,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/go-github/v88 v88.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect


### PR DESCRIPTION
### Description of your changes

Several of the bundled terraform-provider-github resources return a hard error from
`Read` when their parent object no longer exists, instead of clearing the ID and
returning `nil` as the terraform-plugin-sdk contract requires.

That is fatal for a managed resource. upjet's SDK external client calls
`schema.Resource.RefreshWithoutUpgrade`, which surfaces the error diagnostic as an
error from `Observe` rather than `ResourceExists: false`. The crossplane-runtime
managed reconciler then never removes the delete finalizer, so the child MR stays in
`Terminating` forever and re-reads indefinitely:

```
Warning  CannotObserveExternalResource  managed/.../kind=teamrepository
  failed to observe the resource: [{0 GET https://api.github.com/orgs/<org>/teams/<slug>: 404 Not Found [] []}]
```

Deleting a parent repository or team before its children — an entirely ordinary
ordering — leaves resources a user cannot clean up without hand-editing finalizers.

`config/parent_deletion.go` wraps the affected resources' read functions on the
in-memory `*schema.Provider` at the `WithTerraformProvider` call site (both the
cluster and namespaced providers), so a missing parent becomes the SDK's "gone"
signal (`SetId("")` + nil) instead of a hard error. Every other error — 401/403/5xx,
network — is propagated unchanged, so a transient failure never orphans a live
resource.

There are three groups, because the resources fail in three different ways:

1. Repository children exposing the legacy `Read` field. The wrapper runs before the
   SDK flattens the Go error into a diagnostic, so the typed `*github.ErrorResponse`
   is still available to `errors.As`.
2. Team children whose `ReadContext` resolves the parent team by slug
   (`getTeamID`/`lookupTeamID` → `Teams.GetTeamBySlug`) and returns `diag.FromErr` on
   the lookup 404. `diag.FromErr` keeps only `err.Error()` and discards the wrapped
   error, so `errors.As` is impossible and the rendered status is matched instead —
   anchored to the two positions `(*github.ErrorResponse).Error()` renders it in, not
   any space-delimited `404`.
3. `github_repository_file`, whose content lookup is guarded but whose commit lookup
   is not, for either of its two "gone" outcomes.

### Per-resource verification (terraform-provider-github v6.13.0, as pinned)

Every entry was read at the source, and resources that already satisfy the contract
are excluded rather than carried, so the workaround stays scoped to what needs it.

Included — these return a hard error when the parent is gone:

| Resource | Read field | Failure |
|---|---|---|
| `github_issue_labels` | `Read` | `listLabels` → bare `return err` |
| `github_repository_dependabot_security_updates` | `Read` | `GetAutomatedSecurityFixes` → bare `return err` |
| `github_actions_repository_access_level` | `Read` | `GetActionsAccessLevel` → bare `return err` |
| `github_actions_repository_permissions` | `Read` | `GetActionsPermissions` → bare `return err` |
| `github_workflow_repository_permissions` | `Read` | `GetDefaultWorkflowPermissions` → bare `return err` |
| `github_team_repository` | `ReadContext` | `getTeamID` → `diag.FromErr`; the 404 branch exists only later, on `IsTeamRepoByID` |
| `github_team_membership` | `ReadContext` | `getTeamID` → `diag.FromErr`; 404 branch only later, on `GetTeamMembershipByID` |
| `github_team_members` | `ReadContext` | `lookupTeamID` → `diag.FromErr`; 404 branch only later, on the membership listing |
| `github_repository_file` | `ReadContext` | commit lookup (`GetCommit`, else `getFileCommit`) → bare `diag.FromErr`, for both a 404 and an exhausted commit list |

Excluded — already clear the ID on a 404:

| Resource | Already handled by |
|---|---|
| `github_repository_custom_property` | `errors.AsType[*github.ErrorResponse]` → `SetId("")` |
| `github_repository_ruleset` | `errors.As` → `SetId("")` on the `GetRuleset` 404 |
| `github_branch_default` | `errors.AsType` → `SetId("")` on the `Repositories.Get` 404 |
| `github_repository_collaborators` | `errors.AsType` → `SetId("")` |
| `github_branch_protection` | GraphQL "Could not resolve to a node with the global id" → `SetId("")` |
| `github_app_installation_repository` | `SetId("")` when the repo is absent from the installation list |
| `github_team` | resolves by numeric ID; already clears the ID on a 404 |
| `github_emu_group_mapping`, `github_team_sync_group_mapping` | already clear the ID on a 404 |
| `github_actions_organization_permissions` | org-scoped, not a repository child |
| `github_team_settings` | resolves the team via GraphQL, so there is no REST 404 to match (see caveats) |

### Relationship to the upstream terraform provider

This is a provider-side bridge, not the real fix. The root cause is the Read-contract
violation in terraform-provider-github, and fixes are being submitted there —
[integrations/terraform-provider-github#3587](https://github.com/integrations/terraform-provider-github/pull/3587)
is the first, covering `github_repository_file`'s commit lookup (it adds a sentinel
error so the exhausted-commit-list case can be matched with `errors.Is` instead of by
string).

Each entry here is designed to be deleted: as the pinned terraform-provider-github
version starts handling its own 404s, the corresponding list entry — and eventually
the whole file — can be removed with no behaviour change.

### How has this code been tested

`config/parent_deletion_test.go`, 14 tests / 24 subtests, three kinds:

- Behaviour — a 404, and for `github_repository_file` an exhausted commit list, maps
  to `SetId("")` + nil; 403 / 500 / network / nil errors are propagated unchanged,
  asserting the returned diagnostic summary equals the input rather than merely that
  an error occurred. A `%w`-wrapped 404 is still detected.
- Wiring guards — each listed resource must exist in the provider schema and expose
  the field its wrapper replaces. Without this a renamed or typo'd key would be a
  silent no-op, since the wrappers skip unknown keys.
- Composition — `withParentDeletionWorkaround` actually replaces each read function
  (the function pointer changes), which the wiring guard alone would not catch.

Both string anchors are demonstrated load-bearing by reverting them: relaxing the 404
anchor to any space-delimited `404` makes a path like `docs/error 404 page.html` read
as an HTTP 404, and relaxing the exhaustion anchor to a plain substring match makes
three near-miss errors read as "gone". Each breaks the corresponding test.

`make reviewable` passes. One note for anyone running it locally: `make lint` needs
`GOLANGCILINT_VERSION=2.12.2`, because the Makefile pins 2.7.2, whose binary is built
with go1.25 and refuses this go1.26.2 module. CI is unaffected — its lint job uses
`golangci-lint-action` at v2.12.2 rather than `make lint`. That mismatch is
pre-existing on `main` and left alone here.

### Caveats

- GitHub returns 404, not 403, for objects a token cannot see, so at this layer a
  permissions blip is indistinguishable from a genuine deletion and will be treated as
  gone — which for a live resource drops the delete finalizer early. This is the
  central trade-off. It is bounded to the listed resources, and a wedged resource needs
  manual finalizer surgery to recover, so I judged it the better failure mode. Worth a
  maintainer's opinion.
- The exhaustion match depends on an upstream message string. If
  terraform-provider-github rewords `cannot find file %s in repo %s/%s` the anchor
  stops matching and that resource wedges again rather than deleting spuriously — the
  safe direction, but silent. #3587 replaces it with a sentinel.
- `SetId("")` on a non-deleting reconcile makes upjet report `resourceExists=false`, so
  a live child whose parent vanished out-of-band enters a create-retry loop rather than
  becoming healthy. Better than wedging deletion, but not a repair.
- Verified statically: the verdicts come from reading v6.13.0's read paths and the
  tests are unit-level, so the nine resources have not been driven through a live
  teardown. `github_team_settings` is excluded on the expectation that a missing team
  returns a null Team rather than a 404 — inferred from the resource code, not
  confirmed against live GraphQL.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9
