### PR TITLE
fix(clients): bound the secondary rate limit cooldown

### DIFF
--- a/internal/clients/github.go
+++ b/internal/clients/github.go
@@ -7,6 +7,8 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -166,12 +168,34 @@ const (
 	tfSetupMaxHold = time.Minute * 30
 
 	tfSetupCacheTTL = githubInstallationTokenLifetime - tfSetupMaxHold
+
+	// envLegacyClient is terraform-provider-github's own environment variable for
+	// the legacy_client setting.
+	envLegacyClient = "GITHUB_LEGACY_CLIENT"
 )
+
+// legacyClientEnabled mirrors how terraform-provider-github resolves
+// legacy_client: from GITHUB_LEGACY_CLIENT, defaulting to true when unset or
+// unparseable. The setting is not part of this provider's credentials blob, so
+// the environment variable is the only source.
+func legacyClientEnabled() bool {
+	v, ok := os.LookupEnv(envLegacyClient)
+	if !ok {
+		return true
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		return true
+	}
+	return enabled
+}
 
 // TerraformSetupBuilder builds Terraform a terraform.SetupFn function which returns Terraform provider setup configuration
 //
 //gocyclo:ignore
 func TerraformSetupBuilder(tfProvider *schema.Provider, l logging.Logger) terraform.SetupFn {
+	installTransports()
+
 	var tfSetupLock sync.RWMutex
 	tfSetups := make(map[string]CachedTerraformSetup)
 	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {

--- a/internal/clients/secondarylimit.go
+++ b/internal/clients/secondarylimit.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	// secondaryLimitCooldownCap bounds how long the client will stop sending
+	// requests after a secondary rate limit that GitHub gave no Retry-After for.
+	secondaryLimitCooldownCap = 15 * time.Second
+
+	headerRetryAfter         = "Retry-After"
+	headerRateLimitReset     = "X-RateLimit-Reset"
+	headerRateLimitRemaining = "X-RateLimit-Remaining"
+)
+
+// boundSecondaryLimitCooldown caps the cooldown the rate limiter above it derives
+// from a secondary rate limit response.
+//
+// That limiter parks every subsequent request until the cooldown ends. Lacking a
+// Retry-After it falls back to X-RateLimit-Reset, which carries the *primary*
+// hourly reset and so can be most of an hour away. Every request then outlives its
+// reconcile deadline, and the limiter issues them anyway once the wait is cut
+// short, so the provider reports a rate limit as "context deadline exceeded" while
+// no request reaches GitHub at all. One repository's write loop takes down reads
+// for every GitHub resource on the control plane.
+//
+// Rewriting the reset rather than setting a Retry-After is deliberate: the retrying
+// transport in the same chain honours Retry-After, so supplying one would turn a
+// single wait into several and spend the deadline that way instead.
+type boundSecondaryLimitCooldown struct {
+	base http.RoundTripper
+	cap  time.Duration
+	now  func() time.Time
+}
+
+// withBoundedSecondaryLimitCooldown caps the cooldown the rate limiter above the
+// chain derives from a secondary rate limit response.
+func withBoundedSecondaryLimitCooldown(cooldownCap time.Duration) transportWrapper {
+	return func(base http.RoundTripper) http.RoundTripper {
+		return newBoundSecondaryLimitCooldown(base, cooldownCap)
+	}
+}
+
+func newBoundSecondaryLimitCooldown(base http.RoundTripper, cooldownCap time.Duration) *boundSecondaryLimitCooldown {
+	return &boundSecondaryLimitCooldown{base: base, cap: cooldownCap, now: time.Now}
+}
+
+func (b *boundSecondaryLimitCooldown) unwrap() http.RoundTripper { return b.base }
+
+func (b *boundSecondaryLimitCooldown) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := b.base.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+
+	if reset, ok := b.overlongSecondaryCooldown(resp); ok {
+		resp.Header.Set(headerRateLimitReset, strconv.FormatInt(reset.Unix(), 10))
+	}
+
+	return resp, nil
+}
+
+// overlongSecondaryCooldown reports the capped reset for a secondary rate limit
+// response whose reset is further out than the cap, and whether to apply it.
+//
+// A response carrying a Retry-After is left alone: GitHub said how long to wait,
+// and that value is the one to honour. A response with no requests remaining is a
+// *primary* rate limit, whose reset is authoritative and drives a different
+// limiter, so it is left alone too.
+//
+// The body is deliberately not inspected, although that is part of how the limiter
+// above identifies a secondary rate limit. Being wrong here is inert: a response
+// that limiter does not classify as a secondary rate limit never has its reset read
+// for a cooldown.
+func (b *boundSecondaryLimitCooldown) overlongSecondaryCooldown(resp *http.Response) (time.Time, bool) {
+	switch resp.StatusCode {
+	case http.StatusForbidden, http.StatusTooManyRequests:
+	default:
+		return time.Time{}, false
+	}
+
+	if resp.Header == nil || resp.Header.Get(headerRetryAfter) != "" {
+		return time.Time{}, false
+	}
+
+	if remaining, err := strconv.ParseInt(resp.Header.Get(headerRateLimitRemaining), 10, 64); err == nil && remaining <= 0 {
+		return time.Time{}, false
+	}
+
+	seconds, err := strconv.ParseInt(resp.Header.Get(headerRateLimitReset), 10, 64)
+	if err != nil || seconds <= 0 {
+		return time.Time{}, false
+	}
+
+	capped := b.now().Add(b.cap)
+	if !time.Unix(seconds, 0).After(capped) {
+		return time.Time{}, false
+	}
+
+	return capped, true
+}

--- a/internal/clients/secondarylimit_test.go
+++ b/internal/clients/secondarylimit_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// stubTransport answers with a fixed status and headers. It builds the response
+// itself rather than taking one from a helper, so no function in this file returns
+// an *http.Response for the caller to have to close.
+type stubTransport struct {
+	status int
+	header http.Header
+}
+
+func (s *stubTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: s.status, Header: s.header, Body: http.NoBody}, nil
+}
+
+func header(pairs ...string) http.Header {
+	h := make(http.Header)
+	for i := 0; i < len(pairs); i += 2 {
+		h.Set(pairs[i], pairs[i+1])
+	}
+	return h
+}
+
+func epoch(t time.Time) string {
+	return strconv.FormatInt(t.Unix(), 10)
+}
+
+func TestBoundSecondaryLimitCooldown(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	cap := 15 * time.Second
+	farOut := epoch(now.Add(50 * time.Minute))
+	soon := epoch(now.Add(5 * time.Second))
+
+	for _, tc := range []struct {
+		name      string
+		status    int
+		header    http.Header
+		wantReset string
+	}{
+		{
+			// The live case: the reset carries the primary hourly window, so the
+			// limiter above would park for the best part of an hour.
+			name:      "caps a secondary limit reset that is further out than the cap",
+			status:    http.StatusTooManyRequests,
+			header:    header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", farOut),
+			wantReset: epoch(now.Add(cap)),
+		},
+		{
+			name:      "caps a 403 secondary limit too",
+			status:    http.StatusForbidden,
+			header:    header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", farOut),
+			wantReset: epoch(now.Add(cap)),
+		},
+		{
+			// GitHub said how long to wait, so that is the value to honour.
+			name:      "leaves a response carrying Retry-After alone",
+			status:    http.StatusTooManyRequests,
+			header:    header("Retry-After", "60", "X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", farOut),
+			wantReset: farOut,
+		},
+		{
+			// No requests remaining is a primary rate limit, whose reset is
+			// authoritative and drives a different limiter.
+			name:      "leaves a primary rate limit alone",
+			status:    http.StatusForbidden,
+			header:    header("X-RateLimit-Remaining", "0", "X-RateLimit-Reset", farOut),
+			wantReset: farOut,
+		},
+		{
+			name:      "leaves a reset already inside the cap alone",
+			status:    http.StatusTooManyRequests,
+			header:    header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", soon),
+			wantReset: soon,
+		},
+		{
+			name:      "leaves a success alone",
+			status:    http.StatusOK,
+			header:    header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", farOut),
+			wantReset: farOut,
+		},
+		{
+			name:      "does nothing when there is no reset to cap",
+			status:    http.StatusTooManyRequests,
+			header:    header("X-RateLimit-Remaining", "4998"),
+			wantReset: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := newBoundSecondaryLimitCooldown(&stubTransport{status: tc.status, header: tc.header}, cap)
+			rt.now = func() time.Time { return now }
+
+			resp, err := rt.RoundTrip(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/repos/o/r", nil))
+			if err != nil {
+				t.Fatalf("RoundTrip() error = %v", err)
+			}
+			defer resp.Body.Close()
+
+			if got := resp.Header.Get("X-RateLimit-Reset"); got != tc.wantReset {
+				t.Errorf("X-RateLimit-Reset = %q, want %q", got, tc.wantReset)
+			}
+		})
+	}
+}
+
+// Supplying a Retry-After would be the obvious way to bound the wait, and it is
+// wrong: the retrying transport in the same chain honours Retry-After, so it would
+// turn one wait into several and spend the reconcile deadline that way instead.
+func TestBoundSecondaryLimitCooldownNeverSetsRetryAfter(t *testing.T) {
+	now := time.Now()
+	h := header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", epoch(now.Add(time.Hour)))
+	rt := newBoundSecondaryLimitCooldown(&stubTransport{status: http.StatusTooManyRequests, header: h}, 15*time.Second)
+
+	resp, err := rt.RoundTrip(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/repos/o/r", nil))
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Retry-After"); got != "" {
+		t.Errorf("Retry-After = %q, want it left unset", got)
+	}
+}

--- a/internal/clients/transport.go
+++ b/internal/clients/transport.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// newClientMaxIdleConns and newClientIdleConnTimeout mirror the REST values
+	// terraform-provider-github applies in its own cloneTransport, which it skips
+	// for a wrapped transport.
+	newClientMaxIdleConns    = 100
+	newClientIdleConnTimeout = 90 * time.Second
+)
+
+// transportWrapper adds one concern to a RoundTripper chain.
+type transportWrapper func(http.RoundTripper) http.RoundTripper
+
+// chainTransports wraps base with each wrapper, the first listed ending up
+// outermost and the last closest to the wire.
+//
+// Nesting the constructors directly reads inside-out, which is the reverse of the
+// order a request travels, and that order is load-bearing. Listing the wrappers
+// outermost-first keeps the declaration in the same order as the request path.
+func chainTransports(base http.RoundTripper, wrappers ...transportWrapper) http.RoundTripper {
+	for i := len(wrappers) - 1; i >= 0; i-- {
+		base = wrappers[i](base)
+	}
+	return base
+}
+
+// unwrapper is implemented by a chain member that delegates to another
+// RoundTripper, so a chain can be walked without knowing how it was assembled.
+type unwrapper interface {
+	unwrap() http.RoundTripper
+}
+
+var installTransportsOnce sync.Once
+
+// installTransports inserts this provider's RoundTrippers underneath the Terraform
+// provider's client stack. It is safe to call more than once; only the first call
+// installs.
+func installTransports() {
+	installTransportsOnce.Do(installTransportChains)
+}
+
+// installTransportChains does the wiring. It is separate from the sync.Once so
+// tests can exercise both the legacy and the new-client path, which the Once would
+// otherwise let only one of them reach.
+func installTransportChains() {
+	if !legacyClientEnabled() {
+		installNewClientTransport()
+	}
+}
+
+// installNewClientTransport wraps http.DefaultTransport, which is where the new
+// client (legacy_client = false) builds its chain from.
+//
+// This is only safe with the legacy client disabled. The Terraform provider
+// asserts http.DefaultTransport to *http.Transport unchecked when it builds an
+// anonymous client, which would panic against a wrapper -- but that call sits
+// inside the provider's `if c.LegacyClient` branch, so it cannot be reached from
+// here.
+//
+// The wrapped base has to carry its own connection tuning. The provider's
+// cloneTransport tunes a value only when it is already a *http.Transport and
+// returns anything else untouched. That is exactly what keeps this wrapper in the
+// chain, and equally what stops the settings it would have applied from being
+// applied.
+func installNewClientTransport() {
+	http.DefaultTransport = chainTransports(tunedBaseTransport(http.DefaultTransport),
+		withBoundedSecondaryLimitCooldown(secondaryLimitCooldownCap),
+	)
+}
+
+// tunedBaseTransport clones tr and applies the connection settings the Terraform
+// provider's cloneTransport applies to a REST client. Its GraphQL clients are
+// tuned a little differently there (fewer idle connections, longer idle timeout)
+// and inherit these REST values instead, which affects connection reuse only.
+func tunedBaseTransport(tr http.RoundTripper) http.RoundTripper {
+	base, ok := tr.(*http.Transport)
+	if !ok {
+		return tr
+	}
+
+	tuned := base.Clone()
+	tuned.ForceAttemptHTTP2 = true
+	tuned.MaxIdleConns = newClientMaxIdleConns
+	tuned.MaxIdleConnsPerHost = newClientMaxIdleConns
+	tuned.IdleConnTimeout = newClientIdleConnTimeout
+	return tuned
+}

--- a/internal/clients/transport_test.go
+++ b/internal/clients/transport_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// chainTypes names each member of a RoundTripper chain, outermost first, so a test
+// can assert composition order without reaching into any wrapper's fields.
+func chainTypes(rt http.RoundTripper) []string {
+	var types []string
+	for rt != nil {
+		types = append(types, fmt.Sprintf("%T", rt))
+		next, ok := rt.(unwrapper)
+		if !ok {
+			break
+		}
+		rt = next.unwrap()
+	}
+	return types
+}
+
+// assertChainOrder checks that want is the leading prefix of the chain's types.
+func assertChainOrder(t *testing.T, rt http.RoundTripper, want ...string) {
+	t.Helper()
+	got := chainTypes(rt)
+	if len(got) < len(want) {
+		t.Fatalf("chain is %v, want it to start with %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("chain is %v, want it to start with %v", got, want)
+		}
+	}
+}
+
+type namedTransport struct {
+	name  string
+	inner http.RoundTripper
+	order *[]string
+}
+
+func (n *namedTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	*n.order = append(*n.order, n.name)
+	if n.inner == nil {
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	}
+	return n.inner.RoundTrip(r)
+}
+
+func (n *namedTransport) unwrap() http.RoundTripper { return n.inner }
+
+func named(name string, order *[]string) transportWrapper {
+	return func(base http.RoundTripper) http.RoundTripper {
+		return &namedTransport{name: name, inner: base, order: order}
+	}
+}
+
+// The first wrapper listed must end up outermost, so the declaration reads in the
+// same order a request travels.
+func TestChainTransportsWrapsFirstListedOutermost(t *testing.T) {
+	var order []string
+	base := &namedTransport{name: "base", order: &order}
+
+	rt := chainTransports(base, named("outer", &order), named("inner", &order))
+
+	resp, err := rt.RoundTrip(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/", nil))
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	want := []string{"outer", "inner", "base"}
+	if len(order) != len(want) {
+		t.Fatalf("request path = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("request path = %v, want %v", order, want)
+		}
+	}
+}
+
+func TestChainTransportsWithNoWrappersReturnsBase(t *testing.T) {
+	var order []string
+	base := &namedTransport{name: "base", order: &order}
+
+	if got := chainTransports(base); got != http.RoundTripper(base) {
+		t.Errorf("chainTransports(base) = %T, want the base unchanged", got)
+	}
+}
+
+// cloneTransportRetains mirrors the type switch in terraform-provider-github's
+// cloneTransport (internal/ghclient/transport.go): it tunes a concrete
+// *http.Transport by cloning it, and returns any other RoundTripper unchanged.
+// A wrapper is only reachable from the new client's chain if it is returned
+// unchanged, so this is the property the whole seam depends on.
+func cloneTransportRetains(rt http.RoundTripper) bool {
+	_, concrete := rt.(*http.Transport)
+	return !concrete
+}
+
+func TestInstallNewClientTransport_SurvivesCloneTransport(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+
+	installNewClientTransport()
+
+	assertChainOrder(t, http.DefaultTransport,
+		"*clients.boundSecondaryLimitCooldown")
+	if !cloneTransportRetains(http.DefaultTransport) {
+		t.Error("cloneTransport would swap the wrapper for a tuned clone, dropping the counter out of the new client's chain")
+	}
+}
+
+// The wiring itself: DefaultTransport must be wrapped when the new client is in
+// use and left concrete when it is not. This is what was missing -- the counter
+// was installed only where the legacy client would find it, so on a
+// legacy_client=false control plane it reported nothing at all.
+func TestInstallTransports_WrapsDefaultTransportOnlyForNewClient(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		legacy      string
+		wantWrapped bool
+	}{
+		{name: "new client wraps DefaultTransport so its chain is reachable", legacy: "false", wantWrapped: true},
+		{name: "legacy client leaves DefaultTransport concrete so the provider's unchecked assertion holds", legacy: "true", wantWrapped: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			originalTransport := http.DefaultTransport
+			originalClient := http.DefaultClient.Transport
+			t.Cleanup(func() {
+				http.DefaultTransport = originalTransport
+				http.DefaultClient.Transport = originalClient
+			})
+			t.Setenv(envLegacyClient, tc.legacy)
+
+			installTransportChains()
+
+			_, concrete := http.DefaultTransport.(*http.Transport)
+			if wrapped := !concrete; wrapped != tc.wantWrapped {
+				t.Errorf("http.DefaultTransport is %T (wrapped=%v), want wrapped=%v", http.DefaultTransport, wrapped, tc.wantWrapped)
+			}
+
+			if tc.wantWrapped {
+				assertChainOrder(t, http.DefaultTransport, "*clients.boundSecondaryLimitCooldown")
+			}
+		})
+	}
+}
+
+func TestTunedBaseTransport_CarriesRESTTuning(t *testing.T) {
+	base := &http.Transport{MaxIdleConns: 1, MaxIdleConnsPerHost: 1, IdleConnTimeout: time.Second}
+
+	tuned, ok := tunedBaseTransport(base).(*http.Transport)
+	if !ok {
+		t.Fatalf("tunedBaseTransport returned %T, want *http.Transport", tunedBaseTransport(base))
+	}
+
+	if !tuned.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 = false, want true")
+	}
+	if tuned.MaxIdleConns != newClientMaxIdleConns {
+		t.Errorf("MaxIdleConns = %d, want %d", tuned.MaxIdleConns, newClientMaxIdleConns)
+	}
+	if tuned.MaxIdleConnsPerHost != newClientMaxIdleConns {
+		t.Errorf("MaxIdleConnsPerHost = %d, want %d", tuned.MaxIdleConnsPerHost, newClientMaxIdleConns)
+	}
+	if tuned.IdleConnTimeout != newClientIdleConnTimeout {
+		t.Errorf("IdleConnTimeout = %s, want %s", tuned.IdleConnTimeout, newClientIdleConnTimeout)
+	}
+
+	// The caller's transport must not be mutated; it is process-wide.
+	if base.MaxIdleConns != 1 {
+		t.Errorf("base transport was mutated: MaxIdleConns = %d, want 1", base.MaxIdleConns)
+	}
+}


### PR DESCRIPTION
A secondary rate limit on one resource can stop every GitHub request the provider makes, for up to an hour, and report the cause as a timeout.

`go-github-ratelimit` waits out a secondary rate limit before sending anything else. When the response carries no `Retry-After` it takes the cooldown from `X-RateLimit-Reset` — the primary hourly reset, so potentially most of an hour away. Requests then outlive their reconcile deadline. `waitForRateLimit` discards the cancellation and sends the request anyway on a dead context, so the caller gets `context deadline exceeded` and the request never reaches GitHub. With no response, the cooldown is never re-evaluated either.

On a control plane with roughly a thousand GitHub managed resources this presented as:

| | |
|---|---|
| upjet read duration | pinned at the 180s ceiling, up from 0.2s |
| requests on the wire | none, across every method and status |
| 429s | none, because nothing was being sent |
| provider CPU | idle |

Every signal pointed away from a rate limit.

This caps that fallback at 15s. The limiter still backs off, but within a reconcile deadline, and a real 429 reaches the caller as a rate limit rather than a timeout.

The cap rewrites the reset rather than supplying a `Retry-After`, because the retrying transport in the same chain honours `Retry-After` and `max_retries` defaults to 3 — a `Retry-After` would turn one wait into several and spend the deadline that way instead. There is a test for that.

Three cases are left alone, each with a test:

- a response carrying `Retry-After`, since GitHub said how long to wait
- a response with no requests remaining, since that is a primary rate limit whose reset drives a different limiter
- a reset already inside the cap

The body is not inspected, although the limiter uses it to identify a secondary rate limit. Being wrong there is inert: a response the limiter does not classify as one never has its reset read for a cooldown.

## Installing it

There is no hook for this in terraform-provider-github, so the transport wraps `http.DefaultTransport`, which is where the new client builds its chain from. `cloneTransport` tunes a value only when it is already a `*http.Transport` and returns anything else unchanged — that is what keeps the wrapper in the chain, and also what stops the connection settings it would have applied from being applied, so the wrapper carries them itself.

Only wrapped when the legacy client is disabled. The provider asserts `http.DefaultTransport` to `*http.Transport` unchecked when building an anonymous client, which would panic against a wrapper, but that call sits inside its `if c.LegacyClient` branch.

## Scope

This does not make GitHub reachable during a cooldown; nothing can. It stops one resource taking the rest down with it, and makes the failure legible.

The better fix belongs in `go-github-ratelimit`, whose `waitForRateLimit` should return its context error rather than discard it and send a doomed request. That is not reachable from here — the limiter is constructed inside terraform-provider-github's `internal/ghclient`. Happy to raise it there too.
