### PR TITLE
feat(clients): count GitHub API requests by route and response status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/integrations/terraform-provider-github/v6 v6.13.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.22.0
 	k8s.io/api v0.34.3
 	k8s.io/apiextensions-apiserver v0.34.3
 	k8s.io/apimachinery v0.36.3
@@ -82,6 +83,7 @@ require (
 	github.com/jferrl/go-githubauth v1.7.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -98,7 +100,6 @@ require (
 	github.com/oklog/run v1.2.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.23.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/internal/clients/github.go
+++ b/internal/clients/github.go
@@ -7,6 +7,8 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -166,12 +168,34 @@ const (
 	tfSetupMaxHold = time.Minute * 30
 
 	tfSetupCacheTTL = githubInstallationTokenLifetime - tfSetupMaxHold
+
+	// envLegacyClient is terraform-provider-github's own environment variable for
+	// the legacy_client setting.
+	envLegacyClient = "GITHUB_LEGACY_CLIENT"
 )
+
+// legacyClientEnabled mirrors how terraform-provider-github resolves
+// legacy_client: from GITHUB_LEGACY_CLIENT, defaulting to true when unset or
+// unparseable. The setting is not part of this provider's credentials blob, so
+// the environment variable is the only source.
+func legacyClientEnabled() bool {
+	v, ok := os.LookupEnv(envLegacyClient)
+	if !ok {
+		return true
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		return true
+	}
+	return enabled
+}
 
 // TerraformSetupBuilder builds Terraform a terraform.SetupFn function which returns Terraform provider setup configuration
 //
 //gocyclo:ignore
 func TerraformSetupBuilder(tfProvider *schema.Provider, l logging.Logger) terraform.SetupFn {
+	installTransports()
+
 	var tfSetupLock sync.RWMutex
 	tfSetups := make(map[string]CachedTerraformSetup)
 	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {

--- a/internal/clients/metrics.go
+++ b/internal/clients/metrics.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// routePlaceholder replaces a path segment that is not a known GitHub API
+	// literal (an owner, repository, team slug, ref, ID, ...).
+	routePlaceholder = ":x"
+
+	// routeOther is the label used once maxRouteLabels distinct routes have
+	// been seen. It is the hard bound on the route label's cardinality.
+	routeOther = "other"
+
+	// serviceUnknown is the service label for a path with no recognisable
+	// leading GitHub API literal.
+	serviceUnknown = "unknown"
+
+	// maxRouteLabels bounds the number of distinct route label values.
+	maxRouteLabels = 200
+
+	// maxRouteSegments bounds the depth of a route label.
+	maxRouteSegments = 8
+
+	// statusTransportError is the status label used when the request failed
+	// before a response was received.
+	statusTransportError = "error"
+)
+
+// githubAPIRequests counts GitHub API requests by method, templated route and
+// response status. Status is a first-class label because only 304 Not Modified
+// responses are exempt from GitHub's primary rate limit, so the 304-vs-200 split
+// measures how much of the provider's read traffic is answered conditionally.
+var githubAPIRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "github_api",
+	Name:      "requests_total",
+	Help:      "The number of GitHub API requests made by the provider, by method, route and response status.",
+}, []string{"method", "route", "status"})
+
+// metricsRoundTripper counts every request it forwards. It sits below the
+// Terraform provider's conditional-request layer, so a 304 from GitHub is
+// observed as a 304 rather than as the caller-visible unchanged read.
+//
+// Being installed on http.DefaultClient means any other traffic through that
+// client is counted as well. In this process that is GitHub API traffic; the
+// Kubernetes clients build their own transports.
+type metricsRoundTripper struct {
+	base             http.RoundTripper
+	requests         *prometheus.CounterVec
+	externalAPICalls *prometheus.CounterVec
+	routes           *routeLimiter
+}
+
+// withRequestMetrics counts every request forwarded through the chain.
+func withRequestMetrics(requests, externalAPICalls *prometheus.CounterVec) transportWrapper {
+	return func(base http.RoundTripper) http.RoundTripper {
+		return newMetricsRoundTripper(base, requests, externalAPICalls)
+	}
+}
+
+func newMetricsRoundTripper(base http.RoundTripper, requests, externalAPICalls *prometheus.CounterVec) *metricsRoundTripper {
+	return &metricsRoundTripper{
+		base:             base,
+		requests:         requests,
+		externalAPICalls: externalAPICalls,
+		routes:           newRouteLimiter(maxRouteLabels),
+	}
+}
+
+func (m *metricsRoundTripper) unwrap() http.RoundTripper { return m.base }
+
+func (m *metricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := m.base.RoundTrip(req)
+
+	template := ""
+	if req.URL != nil {
+		template = templateRoute(req.URL.Path)
+	}
+
+	status := statusTransportError
+	if resp != nil {
+		status = strconv.Itoa(resp.StatusCode)
+	}
+
+	m.requests.WithLabelValues(req.Method, m.routes.label(template), status).Inc()
+
+	// Also feed upjet's generic external-API counter, whose timeseries budget is
+	// shared with the other upjet providers. It gets the coarse service name and
+	// the method, which is the (service, operation) shape the AWS, Azure and GCP
+	// providers report; the full route template stays on githubAPIRequests.
+	if m.externalAPICalls != nil {
+		m.externalAPICalls.WithLabelValues(serviceLabel(template), req.Method).Inc()
+	}
+
+	return resp, err
+}
+
+// serviceLabel reduces a route template to a coarse GitHub API service name, so
+// the shared upjet counter stays at roughly the cardinality the other providers
+// give it rather than gaining a value per route.
+func serviceLabel(template string) string {
+	for _, s := range strings.Split(strings.Trim(template, "/"), "/") {
+		switch s {
+		case "", routePlaceholder, "api", "v3":
+			continue
+		default:
+			return s
+		}
+	}
+	return serviceUnknown
+}
+
+// routeLimiter caps how many distinct route labels may be emitted, collapsing
+// everything beyond the cap into routeOther.
+type routeLimiter struct {
+	mu   sync.Mutex
+	seen map[string]struct{}
+	max  int
+}
+
+func newRouteLimiter(max int) *routeLimiter {
+	return &routeLimiter{seen: make(map[string]struct{}, max), max: max}
+}
+
+func (l *routeLimiter) label(route string) string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, ok := l.seen[route]; ok {
+		return route
+	}
+	if len(l.seen) >= l.max {
+		return routeOther
+	}
+	l.seen[route] = struct{}{}
+	return route
+}
+
+// templateRoute turns a request path into a bounded route template by keeping
+// path segments that are known GitHub API literals and replacing every other
+// segment with routePlaceholder.
+//
+// Doing it this way round is what bounds the label. A literal missing from
+// knownRouteSegments merges two routes into one, which loses detail but cannot
+// grow the label set. The only way to grow it is a variable segment that
+// happens to equal a known literal (a repository actually named "issues"), and
+// routeLimiter's cap bounds that.
+func templateRoute(path string) string {
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	if len(segments) == 1 && segments[0] == "" {
+		return "/"
+	}
+
+	truncated := false
+	if len(segments) > maxRouteSegments {
+		segments = segments[:maxRouteSegments]
+		truncated = true
+	}
+
+	out := make([]string, 0, len(segments)+1)
+	for _, s := range segments {
+		lower := strings.ToLower(s)
+		if _, ok := knownRouteSegments[lower]; ok {
+			out = append(out, lower)
+			continue
+		}
+		out = append(out, routePlaceholder)
+	}
+	if truncated {
+		out = append(out, "...")
+	}
+
+	return "/" + strings.Join(out, "/")
+}
+
+// knownRouteSegments are the static path segments of the GitHub API endpoints
+// this provider uses. It does not need to be exhaustive; see templateRoute.
+var knownRouteSegments = map[string]struct{}{
+	// GHES / GraphQL prefixes
+	"api": {}, "v3": {}, "graphql": {}, "rate_limit": {}, "meta": {},
+
+	// top level
+	"app": {}, "applications": {}, "enterprises": {}, "installation": {},
+	"installations": {}, "licenses": {}, "orgs": {}, "repos": {}, "search": {},
+	"teams": {}, "user": {}, "users": {},
+
+	// repository sub-resources
+	"actions": {}, "activity": {}, "assignees": {}, "attestations": {},
+	"autolinks": {}, "branches": {}, "check-runs": {}, "check-suites": {},
+	"code-scanning": {}, "codeowners": {}, "collaborators": {}, "comments": {},
+	"commits": {}, "compare": {}, "contents": {}, "contributors": {},
+	"custom-properties": {}, "dependabot": {}, "dependency-graph": {},
+	"deployments": {}, "dispatches": {}, "environments": {}, "events": {},
+	"forks": {}, "generate": {}, "git": {}, "hooks": {}, "invitations": {},
+	"issues": {}, "keys": {}, "labels": {}, "languages": {}, "merges": {},
+	"milestones": {}, "notifications": {}, "pages": {}, "projects": {},
+	"properties": {}, "pulls": {}, "readme": {}, "releases": {},
+	"rule-suites": {}, "rules": {}, "rulesets": {}, "secret-scanning": {},
+	"stargazers": {}, "statuses": {}, "subscribers": {}, "subscription": {},
+	"tags": {}, "topics": {}, "transfer": {}, "vulnerability-alerts": {},
+	"private-vulnerability-reporting": {},
+
+	// git database
+	"blobs": {}, "matching-refs": {}, "refs": {}, "trees": {},
+
+	// branch protection
+	"protection": {}, "rename": {}, "enforce_admins": {},
+	"required_pull_request_reviews": {}, "required_signatures": {},
+	"required_status_checks": {}, "restrictions": {}, "contexts": {},
+
+	// actions
+	"artifacts": {}, "caches": {}, "jobs": {}, "logs": {}, "oidc": {},
+	"permissions": {}, "public-key": {}, "registration-token": {},
+	"remove-token": {}, "runner-groups": {}, "runners": {}, "runs": {},
+	"secrets": {}, "selected-actions": {}, "sub": {}, "variables": {},
+	"workflows": {}, "access": {}, "customization": {},
+	"deployment-branch-policies": {}, "deployment-protection-rules": {},
+
+	// org / team sub-resources
+	"audit-log": {}, "blocks": {}, "copilot": {},
+	"credential-authorizations": {}, "external-group": {},
+	"external-groups": {}, "failed_invitations": {}, "memberships": {},
+	"members": {}, "outside_collaborators": {},
+	"personal-access-tokens": {}, "public_members": {},
+	"security-managers": {}, "settings": {}, "schema": {}, "team-sync": {},
+	"group-mappings": {}, "discussions": {},
+
+	// user sub-resources
+	"emails": {}, "followers": {}, "following": {}, "gpg_keys": {},
+	"ssh_signing_keys": {}, "starred": {}, "subscriptions": {},
+
+	// app
+	"config": {}, "deliveries": {}, "hook": {}, "manifests": {},
+	"access_tokens": {},
+}

--- a/internal/clients/metrics_test.go
+++ b/internal/clients/metrics_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	tpg "github.com/integrations/terraform-provider-github/v6/github"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// stubRoundTripper returns a canned status (or error) without touching the network.
+type stubRoundTripper struct {
+	status int
+	err    error
+	calls  atomic.Int64
+}
+
+func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.calls.Add(1)
+	if s.err != nil {
+		return nil, s.err
+	}
+	rec := httptest.NewRecorder()
+	rec.WriteHeader(s.status)
+	return rec.Result(), nil
+}
+
+// newTestCounters returns fresh, unregistered counters so tests never depend on
+// package-global state or on each other's ordering.
+func newTestCounters() (requests, extAPI *prometheus.CounterVec) {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "test_github_api_requests_total",
+			Help: "test",
+		}, []string{"method", "route", "status"}),
+		prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "test_external_api_calls_total",
+			Help: "test",
+		}, []string{"service", "operation"})
+}
+
+func do(t *testing.T, rt http.RoundTripper, method, url string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), method, url, nil)
+	if err != nil {
+		t.Fatalf("cannot build request: %v", err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil && !errors.Is(err, errStub) {
+		t.Fatalf("unexpected RoundTrip error: %v", err)
+	}
+	closeBody(resp)
+}
+
+// closeBody drains nothing and just closes, but a RoundTripper's contract is
+// that the caller owns the body -- and bodyclose enforces it in tests too.
+func closeBody(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+}
+
+var errStub = errors.New("stub transport failure")
+
+// TestMetricsRoundTripper_CountsByStatus is the core assertion: a 200, a 304 and
+// a 403 against the same route must land in three separate series. The 304 split
+// is the point of the metric — only 304 responses are exempt from GitHub's
+// primary rate limit, so a 200-vs-304 ratio is what makes conditional-request
+// effectiveness measurable.
+func TestMetricsRoundTripper_CountsByStatus(t *testing.T) {
+	const url = "https://api.github.com/repos/some-owner/some-repo"
+
+	for _, status := range []int{http.StatusOK, http.StatusNotModified, http.StatusForbidden} {
+		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+			requests, extAPI := newTestCounters()
+			stub := &stubRoundTripper{status: status}
+			rt := newMetricsRoundTripper(stub, requests, extAPI)
+
+			do(t, rt, http.MethodGet, url)
+
+			got := testutil.ToFloat64(requests.WithLabelValues(http.MethodGet, "/repos/:x/:x", fmt.Sprint(status)))
+			if got != 1 {
+				t.Errorf("counter for status %d = %v, want 1", status, got)
+			}
+			if got := stub.calls.Load(); got != 1 {
+				t.Errorf("base transport calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
+// TestMetricsRoundTripper_StatusesAreSeparateSeries pins that a 200 and a 304 on
+// the same route do not collapse into one another.
+func TestMetricsRoundTripper_StatusesAreSeparateSeries(t *testing.T) {
+	requests, extAPI := newTestCounters()
+
+	ok := newMetricsRoundTripper(&stubRoundTripper{status: http.StatusOK}, requests, extAPI)
+	notModified := newMetricsRoundTripper(&stubRoundTripper{status: http.StatusNotModified}, requests, extAPI)
+
+	const url = "https://api.github.com/repos/some-owner/some-repo/branches/main/protection"
+	do(t, ok, http.MethodGet, url)
+	do(t, notModified, http.MethodGet, url)
+	do(t, notModified, http.MethodGet, url)
+
+	const route = "/repos/:x/:x/branches/:x/protection"
+	if got := testutil.ToFloat64(requests.WithLabelValues(http.MethodGet, route, "200")); got != 1 {
+		t.Errorf("200 counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(requests.WithLabelValues(http.MethodGet, route, "304")); got != 2 {
+		t.Errorf("304 counter = %v, want 2", got)
+	}
+}
+
+// TestMetricsRoundTripper_TransportError records a request that never got a
+// response, so failures are not silently uncounted.
+func TestMetricsRoundTripper_TransportError(t *testing.T) {
+	requests, extAPI := newTestCounters()
+	rt := newMetricsRoundTripper(&stubRoundTripper{err: errStub}, requests, extAPI)
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://api.github.com/graphql", nil)
+	resp, err := rt.RoundTrip(req)
+	closeBody(resp)
+	if err == nil {
+		t.Fatal("expected the base transport error to be propagated")
+	}
+	if resp != nil {
+		t.Errorf("expected no response, got %v", resp)
+	}
+
+	if got := testutil.ToFloat64(requests.WithLabelValues(http.MethodPost, "/graphql", statusTransportError)); got != 1 {
+		t.Errorf("error counter = %v, want 1", got)
+	}
+}
+
+// TestMetricsRoundTripper_FeedsUpjetCounter checks the second, already-allowlisted
+// metric keeps the (service, operation) shape the AWS/Azure/GCP providers use.
+func TestMetricsRoundTripper_FeedsUpjetCounter(t *testing.T) {
+	requests, extAPI := newTestCounters()
+	rt := newMetricsRoundTripper(&stubRoundTripper{status: http.StatusOK}, requests, extAPI)
+
+	do(t, rt, http.MethodPatch, "https://api.github.com/orgs/some-org/teams/some-team")
+
+	if got := testutil.ToFloat64(extAPI.WithLabelValues("orgs", http.MethodPatch)); got != 1 {
+		t.Errorf("upjet counter = %v, want 1", got)
+	}
+}
+
+func TestTemplateRoute(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want string
+	}{
+		{"/repos/some-owner/some-repo", "/repos/:x/:x"},
+		{"/repos/some-owner/some-repo/issues/1234/labels", "/repos/:x/:x/issues/:x/labels"},
+		{"/repos/some-owner/some-repo/branches/feature-x/protection/required_status_checks", "/repos/:x/:x/branches/:x/protection/required_status_checks"},
+		{"/orgs/some-org/teams/some-team/memberships/some-user", "/orgs/:x/teams/:x/memberships/:x"},
+		{"/graphql", "/graphql"},
+		{"/api/v3/repos/some-owner/some-repo", "/api/v3/repos/:x/:x"},
+		{"/user", "/user"},
+		{"/", "/"},
+		// Different owners and repositories must collapse onto one route: this
+		// is what keeps the label from growing with the estate.
+		{"/repos/another-owner/another-repo", "/repos/:x/:x"},
+		// Depth is bounded: only maxRouteSegments segments are kept.
+		{"/repos/o/r/a/b/c/d/e/f/g/h", "/repos/:x/:x/:x/:x/:x/:x/:x/..."},
+	} {
+		if got := templateRoute(tc.path); got != tc.want {
+			t.Errorf("templateRoute(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestTemplateRoute_NeverContainsIdentifiers is the cardinality guarantee stated
+// negatively: no owner, repository or ref name may reach a label value.
+func TestTemplateRoute_NeverContainsIdentifiers(t *testing.T) {
+	route := templateRoute("/repos/secret-owner/secret-repo/git/refs/heads/secret-branch")
+	for _, identifier := range []string{"secret-owner", "secret-repo", "secret-branch"} {
+		if strings.Contains(route, identifier) {
+			t.Errorf("route %q leaked identifier %q", route, identifier)
+		}
+	}
+}
+
+func TestRouteLimiter_CapsDistinctRoutes(t *testing.T) {
+	l := newRouteLimiter(3)
+
+	for i := range 3 {
+		route := fmt.Sprintf("/route-%d", i)
+		if got := l.label(route); got != route {
+			t.Errorf("label(%q) = %q, want it kept", route, got)
+		}
+		// Already-seen routes stay themselves.
+		if got := l.label(route); got != route {
+			t.Errorf("repeat label(%q) = %q, want it kept", route, got)
+		}
+	}
+
+	if got := l.label("/route-over-cap"); got != routeOther {
+		t.Errorf("label past the cap = %q, want %q", got, routeOther)
+	}
+	// The cap does not evict what is already tracked.
+	if got := l.label("/route-0"); got != "/route-0" {
+		t.Errorf("label(%q) after the cap = %q, want it kept", "/route-0", got)
+	}
+}
+
+// TestMetricsRoundTripper_Concurrent guards the route table against a data race;
+// meaningful under -race.
+func TestMetricsRoundTripper_Concurrent(t *testing.T) {
+	requests, extAPI := newTestCounters()
+	rt := newMetricsRoundTripper(&stubRoundTripper{status: http.StatusOK}, requests, extAPI)
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("https://api.github.com/repos/owner-%d/repo", i), nil)
+			resp, err := rt.RoundTrip(req)
+			closeBody(resp)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := testutil.ToFloat64(requests.WithLabelValues(http.MethodGet, "/repos/:x/:x", "200")); got != 50 {
+		t.Errorf("counter = %v, want 50", got)
+	}
+}
+
+// TestInstallMetricsTransport_LeavesDefaultTransportAlone pins the reason the
+// hook is http.DefaultClient.Transport: the Terraform provider does an unchecked
+// http.DefaultTransport.(*http.Transport) assertion on its anonymous client path,
+// which would panic if http.DefaultTransport were replaced with a wrapper.
+// With the legacy client in play, http.DefaultTransport must stay a concrete
+// *http.Transport: the Terraform provider type-asserts it unchecked when it
+// builds an anonymous client, and a wrapper there would panic the provider.
+func TestInstallMetricsTransport_LegacyClientLeavesDefaultTransportAlone(t *testing.T) {
+	if !legacyClientEnabled() {
+		t.Skip("GITHUB_LEGACY_CLIENT is disabled here; DefaultTransport is wrapped by design")
+	}
+
+	installTransports()
+
+	if _, ok := http.DefaultTransport.(*http.Transport); !ok {
+		t.Fatalf("http.DefaultTransport is %T, want *http.Transport", http.DefaultTransport)
+	}
+	if _, ok := http.DefaultClient.Transport.(*metricsRoundTripper); !ok {
+		t.Fatalf("http.DefaultClient.Transport is %T, want *metricsRoundTripper", http.DefaultClient.Transport)
+	}
+
+	// Idempotent: a second call must not wrap the wrapper.
+	before := http.DefaultClient.Transport
+	installTransports()
+	if http.DefaultClient.Transport != before {
+		t.Error("installTransports is not idempotent")
+	}
+}
+
+func TestServiceLabel(t *testing.T) {
+	for _, tc := range []struct {
+		template string
+		want     string
+	}{
+		{"/repos/:x/:x/issues/:x/labels", "repos"},
+		{"/orgs/:x/teams/:x/memberships/:x", "orgs"},
+		{"/api/v3/repos/:x/:x", "repos"},
+		{"/graphql", "graphql"},
+		{"/user", "user"},
+		{"/:x/:x", serviceUnknown},
+		{"/", serviceUnknown},
+	} {
+		if got := serviceLabel(tc.template); got != tc.want {
+			t.Errorf("serviceLabel(%q) = %q, want %q", tc.template, got, tc.want)
+		}
+	}
+}
+
+// TestInstalledTransport_CountsTerraformProviderClient is the end-to-end check
+// that matters: it drives the Terraform provider's own client constructor and
+// asserts the request landed on the counter. Asserting that we installed the
+// wrapper is not the same as asserting the provider's client routes through it,
+// and this is what would break if the Terraform provider stopped building its
+// client via oauth2.NewClient.
+func TestInstalledTransport_CountsTerraformProviderClient(t *testing.T) {
+	installTransports()
+
+	rt, ok := http.DefaultClient.Transport.(*metricsRoundTripper)
+	if !ok {
+		t.Fatalf("http.DefaultClient.Transport is %T, want *metricsRoundTripper", http.DefaultClient.Transport)
+	}
+
+	// Count against the installed transport's own counters, isolated per test.
+	requests, extAPI := newTestCounters()
+	rt.requests, rt.externalAPICalls = requests, extAPI
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer srv.Close()
+
+	// A token makes Anonymous() false, which is the authenticated legacy path
+	// that App authentication also resolves to once the installation token is
+	// minted. Zero delays and retries keep the test fast and deterministic.
+	cfg := &tpg.Config{Token: "not-a-real-token"}
+	client := cfg.AuthenticatedHTTPClient()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/repos/some-owner/some-repo", nil)
+	if err != nil {
+		t.Fatalf("cannot build request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request through the provider client failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := testutil.ToFloat64(requests.WithLabelValues(http.MethodGet, "/repos/:x/:x", "304")); got != 1 {
+		t.Errorf("304 counter = %v, want 1: the Terraform provider client did not route through the installed transport", got)
+	}
+	if got := testutil.ToFloat64(extAPI.WithLabelValues("repos", http.MethodGet)); got != 1 {
+		t.Errorf("upjet counter = %v, want 1", got)
+	}
+}
+
+func TestTunedBaseTransport_PassesThroughNonTransport(t *testing.T) {
+	rt := &stubRoundTripper{status: http.StatusOK}
+
+	if got := tunedBaseTransport(rt); got != http.RoundTripper(rt) {
+		t.Errorf("tunedBaseTransport returned %T, want the original RoundTripper unchanged", got)
+	}
+}
+
+// The whole point of wrapping DefaultTransport is that traffic reaching it is
+// counted, including the 304s that make conditional reads free.
+func TestNewClientMetricsTransport_Counts(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+
+	requests, extAPI := newTestCounters()
+	http.DefaultTransport = newMetricsRoundTripper(
+		tunedBaseTransport(&stubRoundTripper{status: http.StatusNotModified}),
+		requests, extAPI,
+	)
+
+	do(t, http.DefaultTransport, http.MethodGet, "https://api.github.com/repos/o/r")
+
+	if got := testutil.ToFloat64(requests.WithLabelValues(http.MethodGet, "/repos/:x/:x", "304")); got != 1 {
+		t.Errorf("304 count = %v, want 1", got)
+	}
+}

--- a/internal/clients/secondarylimit.go
+++ b/internal/clients/secondarylimit.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	// secondaryLimitCooldownCap bounds how long the client will stop sending
+	// requests after a secondary rate limit that GitHub gave no Retry-After for.
+	secondaryLimitCooldownCap = 15 * time.Second
+
+	headerRetryAfter         = "Retry-After"
+	headerRateLimitReset     = "X-RateLimit-Reset"
+	headerRateLimitRemaining = "X-RateLimit-Remaining"
+)
+
+// boundSecondaryLimitCooldown caps the cooldown the rate limiter above it derives
+// from a secondary rate limit response.
+//
+// That limiter parks every subsequent request until the cooldown ends. Lacking a
+// Retry-After it falls back to X-RateLimit-Reset, which carries the *primary*
+// hourly reset and so can be most of an hour away. Every request then outlives its
+// reconcile deadline, and the limiter issues them anyway once the wait is cut
+// short, so the provider reports a rate limit as "context deadline exceeded" while
+// no request reaches GitHub at all. One repository's write loop takes down reads
+// for every GitHub resource on the control plane.
+//
+// Rewriting the reset rather than setting a Retry-After is deliberate: the retrying
+// transport in the same chain honours Retry-After, so supplying one would turn a
+// single wait into several and spend the deadline that way instead.
+type boundSecondaryLimitCooldown struct {
+	base http.RoundTripper
+	cap  time.Duration
+	now  func() time.Time
+}
+
+// withBoundedSecondaryLimitCooldown caps the cooldown the rate limiter above the
+// chain derives from a secondary rate limit response.
+func withBoundedSecondaryLimitCooldown(cooldownCap time.Duration) transportWrapper {
+	return func(base http.RoundTripper) http.RoundTripper {
+		return newBoundSecondaryLimitCooldown(base, cooldownCap)
+	}
+}
+
+func newBoundSecondaryLimitCooldown(base http.RoundTripper, cooldownCap time.Duration) *boundSecondaryLimitCooldown {
+	return &boundSecondaryLimitCooldown{base: base, cap: cooldownCap, now: time.Now}
+}
+
+func (b *boundSecondaryLimitCooldown) unwrap() http.RoundTripper { return b.base }
+
+func (b *boundSecondaryLimitCooldown) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := b.base.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+
+	if reset, ok := b.overlongSecondaryCooldown(resp); ok {
+		resp.Header.Set(headerRateLimitReset, strconv.FormatInt(reset.Unix(), 10))
+	}
+
+	return resp, nil
+}
+
+// overlongSecondaryCooldown reports the capped reset for a secondary rate limit
+// response whose reset is further out than the cap, and whether to apply it.
+//
+// A response carrying a Retry-After is left alone: GitHub said how long to wait,
+// and that value is the one to honour. A response with no requests remaining is a
+// *primary* rate limit, whose reset is authoritative and drives a different
+// limiter, so it is left alone too.
+//
+// The body is deliberately not inspected, although that is part of how the limiter
+// above identifies a secondary rate limit. Being wrong here is inert: a response
+// that limiter does not classify as a secondary rate limit never has its reset read
+// for a cooldown.
+func (b *boundSecondaryLimitCooldown) overlongSecondaryCooldown(resp *http.Response) (time.Time, bool) {
+	switch resp.StatusCode {
+	case http.StatusForbidden, http.StatusTooManyRequests:
+	default:
+		return time.Time{}, false
+	}
+
+	if resp.Header == nil || resp.Header.Get(headerRetryAfter) != "" {
+		return time.Time{}, false
+	}
+
+	if remaining, err := strconv.ParseInt(resp.Header.Get(headerRateLimitRemaining), 10, 64); err == nil && remaining <= 0 {
+		return time.Time{}, false
+	}
+
+	seconds, err := strconv.ParseInt(resp.Header.Get(headerRateLimitReset), 10, 64)
+	if err != nil || seconds <= 0 {
+		return time.Time{}, false
+	}
+
+	capped := b.now().Add(b.cap)
+	if !time.Unix(seconds, 0).After(capped) {
+		return time.Time{}, false
+	}
+
+	return capped, true
+}

--- a/internal/clients/secondarylimit_test.go
+++ b/internal/clients/secondarylimit_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// stubTransport answers with a fixed status and headers. It builds the response
+// itself rather than taking one from a helper, so no function in this file returns
+// an *http.Response for the caller to have to close.
+type stubTransport struct {
+	status int
+	header http.Header
+}
+
+func (s *stubTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: s.status, Header: s.header, Body: http.NoBody}, nil
+}
+
+func header(pairs ...string) http.Header {
+	h := make(http.Header)
+	for i := 0; i < len(pairs); i += 2 {
+		h.Set(pairs[i], pairs[i+1])
+	}
+	return h
+}
+
+func epoch(t time.Time) string {
+	return strconv.FormatInt(t.Unix(), 10)
+}
+
+func TestBoundSecondaryLimitCooldown(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	cap := 15 * time.Second
+	farOut := epoch(now.Add(50 * time.Minute))
+	soon := epoch(now.Add(5 * time.Second))
+
+	for _, tc := range []struct {
+		name      string
+		status    int
+		header    http.Header
+		wantReset string
+	}{
+		{
+			// The live case: the reset carries the primary hourly window, so the
+			// limiter above would park for the best part of an hour.
+			name:      "caps a secondary limit reset that is further out than the cap",
+			status:    http.StatusTooManyRequests,
+			header:    header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", farOut),
+			wantReset: epoch(now.Add(cap)),
+		},
+		{
+			name:      "caps a 403 secondary limit too",
+			status:    http.StatusForbidden,
+			header:    header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", farOut),
+			wantReset: epoch(now.Add(cap)),
+		},
+		{
+			// GitHub said how long to wait, so that is the value to honour.
+			name:      "leaves a response carrying Retry-After alone",
+			status:    http.StatusTooManyRequests,
+			header:    header("Retry-After", "60", "X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", farOut),
+			wantReset: farOut,
+		},
+		{
+			// No requests remaining is a primary rate limit, whose reset is
+			// authoritative and drives a different limiter.
+			name:      "leaves a primary rate limit alone",
+			status:    http.StatusForbidden,
+			header:    header("X-RateLimit-Remaining", "0", "X-RateLimit-Reset", farOut),
+			wantReset: farOut,
+		},
+		{
+			name:      "leaves a reset already inside the cap alone",
+			status:    http.StatusTooManyRequests,
+			header:    header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", soon),
+			wantReset: soon,
+		},
+		{
+			name:      "leaves a success alone",
+			status:    http.StatusOK,
+			header:    header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", farOut),
+			wantReset: farOut,
+		},
+		{
+			name:      "does nothing when there is no reset to cap",
+			status:    http.StatusTooManyRequests,
+			header:    header("X-RateLimit-Remaining", "4998"),
+			wantReset: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := newBoundSecondaryLimitCooldown(&stubTransport{status: tc.status, header: tc.header}, cap)
+			rt.now = func() time.Time { return now }
+
+			resp, err := rt.RoundTrip(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/repos/o/r", nil))
+			if err != nil {
+				t.Fatalf("RoundTrip() error = %v", err)
+			}
+			defer resp.Body.Close()
+
+			if got := resp.Header.Get("X-RateLimit-Reset"); got != tc.wantReset {
+				t.Errorf("X-RateLimit-Reset = %q, want %q", got, tc.wantReset)
+			}
+		})
+	}
+}
+
+// Supplying a Retry-After would be the obvious way to bound the wait, and it is
+// wrong: the retrying transport in the same chain honours Retry-After, so it would
+// turn one wait into several and spend the reconcile deadline that way instead.
+func TestBoundSecondaryLimitCooldownNeverSetsRetryAfter(t *testing.T) {
+	now := time.Now()
+	h := header("X-RateLimit-Remaining", "4998", "X-RateLimit-Reset", epoch(now.Add(time.Hour)))
+	rt := newBoundSecondaryLimitCooldown(&stubTransport{status: http.StatusTooManyRequests, header: h}, 15*time.Second)
+
+	resp, err := rt.RoundTrip(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/repos/o/r", nil))
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Retry-After"); got != "" {
+		t.Errorf("Retry-After = %q, want it left unset", got)
+	}
+}

--- a/internal/clients/transport.go
+++ b/internal/clients/transport.go
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	upjetmetrics "github.com/crossplane/upjet/v2/pkg/metrics"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 const (
@@ -46,13 +49,25 @@ var installTransportsOnce sync.Once
 // provider's client stack. It is safe to call more than once; only the first call
 // installs.
 func installTransports() {
-	installTransportsOnce.Do(installTransportChains)
+	installTransportsOnce.Do(func() {
+		ctrlmetrics.Registry.MustRegister(githubAPIRequests)
+		installTransportChains()
+	})
 }
 
 // installTransportChains does the wiring. It is separate from the sync.Once so
 // tests can exercise both the legacy and the new-client path, which the Once would
 // otherwise let only one of them reach.
+// The legacy client never consults http.DefaultTransport -- it resolves its base
+// RoundTripper from http.DefaultClient, which the Terraform provider builds its
+// authenticated client from -- so that seam is wrapped too, and unconditionally.
 func installTransportChains() {
+	base := http.DefaultClient.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	http.DefaultClient.Transport = newMetricsRoundTripper(base, githubAPIRequests, upjetmetrics.ExternalAPICalls)
+
 	if !legacyClientEnabled() {
 		installNewClientTransport()
 	}
@@ -75,6 +90,7 @@ func installTransportChains() {
 func installNewClientTransport() {
 	http.DefaultTransport = chainTransports(tunedBaseTransport(http.DefaultTransport),
 		withBoundedSecondaryLimitCooldown(secondaryLimitCooldownCap),
+		withRequestMetrics(githubAPIRequests, upjetmetrics.ExternalAPICalls),
 	)
 }
 

--- a/internal/clients/transport.go
+++ b/internal/clients/transport.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// newClientMaxIdleConns and newClientIdleConnTimeout mirror the REST values
+	// terraform-provider-github applies in its own cloneTransport, which it skips
+	// for a wrapped transport.
+	newClientMaxIdleConns    = 100
+	newClientIdleConnTimeout = 90 * time.Second
+)
+
+// transportWrapper adds one concern to a RoundTripper chain.
+type transportWrapper func(http.RoundTripper) http.RoundTripper
+
+// chainTransports wraps base with each wrapper, the first listed ending up
+// outermost and the last closest to the wire.
+//
+// Nesting the constructors directly reads inside-out, which is the reverse of the
+// order a request travels, and that order is load-bearing. Listing the wrappers
+// outermost-first keeps the declaration in the same order as the request path.
+func chainTransports(base http.RoundTripper, wrappers ...transportWrapper) http.RoundTripper {
+	for i := len(wrappers) - 1; i >= 0; i-- {
+		base = wrappers[i](base)
+	}
+	return base
+}
+
+// unwrapper is implemented by a chain member that delegates to another
+// RoundTripper, so a chain can be walked without knowing how it was assembled.
+type unwrapper interface {
+	unwrap() http.RoundTripper
+}
+
+var installTransportsOnce sync.Once
+
+// installTransports inserts this provider's RoundTrippers underneath the Terraform
+// provider's client stack. It is safe to call more than once; only the first call
+// installs.
+func installTransports() {
+	installTransportsOnce.Do(installTransportChains)
+}
+
+// installTransportChains does the wiring. It is separate from the sync.Once so
+// tests can exercise both the legacy and the new-client path, which the Once would
+// otherwise let only one of them reach.
+func installTransportChains() {
+	if !legacyClientEnabled() {
+		installNewClientTransport()
+	}
+}
+
+// installNewClientTransport wraps http.DefaultTransport, which is where the new
+// client (legacy_client = false) builds its chain from.
+//
+// This is only safe with the legacy client disabled. The Terraform provider
+// asserts http.DefaultTransport to *http.Transport unchecked when it builds an
+// anonymous client, which would panic against a wrapper -- but that call sits
+// inside the provider's `if c.LegacyClient` branch, so it cannot be reached from
+// here.
+//
+// The wrapped base has to carry its own connection tuning. The provider's
+// cloneTransport tunes a value only when it is already a *http.Transport and
+// returns anything else untouched. That is exactly what keeps this wrapper in the
+// chain, and equally what stops the settings it would have applied from being
+// applied.
+func installNewClientTransport() {
+	http.DefaultTransport = chainTransports(tunedBaseTransport(http.DefaultTransport),
+		withBoundedSecondaryLimitCooldown(secondaryLimitCooldownCap),
+	)
+}
+
+// tunedBaseTransport clones tr and applies the connection settings the Terraform
+// provider's cloneTransport applies to a REST client. Its GraphQL clients are
+// tuned a little differently there (fewer idle connections, longer idle timeout)
+// and inherit these REST values instead, which affects connection reuse only.
+func tunedBaseTransport(tr http.RoundTripper) http.RoundTripper {
+	base, ok := tr.(*http.Transport)
+	if !ok {
+		return tr
+	}
+
+	tuned := base.Clone()
+	tuned.ForceAttemptHTTP2 = true
+	tuned.MaxIdleConns = newClientMaxIdleConns
+	tuned.MaxIdleConnsPerHost = newClientMaxIdleConns
+	tuned.IdleConnTimeout = newClientIdleConnTimeout
+	return tuned
+}

--- a/internal/clients/transport_test.go
+++ b/internal/clients/transport_test.go
@@ -115,7 +115,7 @@ func TestInstallNewClientTransport_SurvivesCloneTransport(t *testing.T) {
 	installNewClientTransport()
 
 	assertChainOrder(t, http.DefaultTransport,
-		"*clients.boundSecondaryLimitCooldown")
+		"*clients.boundSecondaryLimitCooldown", "*clients.metricsRoundTripper")
 	if !cloneTransportRetains(http.DefaultTransport) {
 		t.Error("cloneTransport would swap the wrapper for a tuned clone, dropping the counter out of the new client's chain")
 	}
@@ -131,7 +131,7 @@ func TestInstallTransports_WrapsDefaultTransportOnlyForNewClient(t *testing.T) {
 		legacy      string
 		wantWrapped bool
 	}{
-		{name: "new client wraps DefaultTransport so its chain is reachable", legacy: "false", wantWrapped: true},
+		{name: "new client wraps DefaultTransport so its chain is counted", legacy: "false", wantWrapped: true},
 		{name: "legacy client leaves DefaultTransport concrete so the provider's unchecked assertion holds", legacy: "true", wantWrapped: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -151,7 +151,8 @@ func TestInstallTransports_WrapsDefaultTransportOnlyForNewClient(t *testing.T) {
 			}
 
 			if tc.wantWrapped {
-				assertChainOrder(t, http.DefaultTransport, "*clients.boundSecondaryLimitCooldown")
+				assertChainOrder(t, http.DefaultTransport,
+					"*clients.boundSecondaryLimitCooldown", "*clients.metricsRoundTripper")
 			}
 		})
 	}

--- a/internal/clients/transport_test.go
+++ b/internal/clients/transport_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// chainTypes names each member of a RoundTripper chain, outermost first, so a test
+// can assert composition order without reaching into any wrapper's fields.
+func chainTypes(rt http.RoundTripper) []string {
+	var types []string
+	for rt != nil {
+		types = append(types, fmt.Sprintf("%T", rt))
+		next, ok := rt.(unwrapper)
+		if !ok {
+			break
+		}
+		rt = next.unwrap()
+	}
+	return types
+}
+
+// assertChainOrder checks that want is the leading prefix of the chain's types.
+func assertChainOrder(t *testing.T, rt http.RoundTripper, want ...string) {
+	t.Helper()
+	got := chainTypes(rt)
+	if len(got) < len(want) {
+		t.Fatalf("chain is %v, want it to start with %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("chain is %v, want it to start with %v", got, want)
+		}
+	}
+}
+
+type namedTransport struct {
+	name  string
+	inner http.RoundTripper
+	order *[]string
+}
+
+func (n *namedTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	*n.order = append(*n.order, n.name)
+	if n.inner == nil {
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	}
+	return n.inner.RoundTrip(r)
+}
+
+func (n *namedTransport) unwrap() http.RoundTripper { return n.inner }
+
+func named(name string, order *[]string) transportWrapper {
+	return func(base http.RoundTripper) http.RoundTripper {
+		return &namedTransport{name: name, inner: base, order: order}
+	}
+}
+
+// The first wrapper listed must end up outermost, so the declaration reads in the
+// same order a request travels.
+func TestChainTransportsWrapsFirstListedOutermost(t *testing.T) {
+	var order []string
+	base := &namedTransport{name: "base", order: &order}
+
+	rt := chainTransports(base, named("outer", &order), named("inner", &order))
+
+	resp, err := rt.RoundTrip(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.com/", nil))
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	want := []string{"outer", "inner", "base"}
+	if len(order) != len(want) {
+		t.Fatalf("request path = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("request path = %v, want %v", order, want)
+		}
+	}
+}
+
+func TestChainTransportsWithNoWrappersReturnsBase(t *testing.T) {
+	var order []string
+	base := &namedTransport{name: "base", order: &order}
+
+	if got := chainTransports(base); got != http.RoundTripper(base) {
+		t.Errorf("chainTransports(base) = %T, want the base unchanged", got)
+	}
+}
+
+// cloneTransportRetains mirrors the type switch in terraform-provider-github's
+// cloneTransport (internal/ghclient/transport.go): it tunes a concrete
+// *http.Transport by cloning it, and returns any other RoundTripper unchanged.
+// A wrapper is only reachable from the new client's chain if it is returned
+// unchanged, so this is the property the whole seam depends on.
+func cloneTransportRetains(rt http.RoundTripper) bool {
+	_, concrete := rt.(*http.Transport)
+	return !concrete
+}
+
+func TestInstallNewClientTransport_SurvivesCloneTransport(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+
+	installNewClientTransport()
+
+	assertChainOrder(t, http.DefaultTransport,
+		"*clients.boundSecondaryLimitCooldown")
+	if !cloneTransportRetains(http.DefaultTransport) {
+		t.Error("cloneTransport would swap the wrapper for a tuned clone, dropping the counter out of the new client's chain")
+	}
+}
+
+// The wiring itself: DefaultTransport must be wrapped when the new client is in
+// use and left concrete when it is not. This is what was missing -- the counter
+// was installed only where the legacy client would find it, so on a
+// legacy_client=false control plane it reported nothing at all.
+func TestInstallTransports_WrapsDefaultTransportOnlyForNewClient(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		legacy      string
+		wantWrapped bool
+	}{
+		{name: "new client wraps DefaultTransport so its chain is reachable", legacy: "false", wantWrapped: true},
+		{name: "legacy client leaves DefaultTransport concrete so the provider's unchecked assertion holds", legacy: "true", wantWrapped: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			originalTransport := http.DefaultTransport
+			originalClient := http.DefaultClient.Transport
+			t.Cleanup(func() {
+				http.DefaultTransport = originalTransport
+				http.DefaultClient.Transport = originalClient
+			})
+			t.Setenv(envLegacyClient, tc.legacy)
+
+			installTransportChains()
+
+			_, concrete := http.DefaultTransport.(*http.Transport)
+			if wrapped := !concrete; wrapped != tc.wantWrapped {
+				t.Errorf("http.DefaultTransport is %T (wrapped=%v), want wrapped=%v", http.DefaultTransport, wrapped, tc.wantWrapped)
+			}
+
+			if tc.wantWrapped {
+				assertChainOrder(t, http.DefaultTransport, "*clients.boundSecondaryLimitCooldown")
+			}
+		})
+	}
+}
+
+func TestTunedBaseTransport_CarriesRESTTuning(t *testing.T) {
+	base := &http.Transport{MaxIdleConns: 1, MaxIdleConnsPerHost: 1, IdleConnTimeout: time.Second}
+
+	tuned, ok := tunedBaseTransport(base).(*http.Transport)
+	if !ok {
+		t.Fatalf("tunedBaseTransport returned %T, want *http.Transport", tunedBaseTransport(base))
+	}
+
+	if !tuned.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 = false, want true")
+	}
+	if tuned.MaxIdleConns != newClientMaxIdleConns {
+		t.Errorf("MaxIdleConns = %d, want %d", tuned.MaxIdleConns, newClientMaxIdleConns)
+	}
+	if tuned.MaxIdleConnsPerHost != newClientMaxIdleConns {
+		t.Errorf("MaxIdleConnsPerHost = %d, want %d", tuned.MaxIdleConnsPerHost, newClientMaxIdleConns)
+	}
+	if tuned.IdleConnTimeout != newClientIdleConnTimeout {
+		t.Errorf("IdleConnTimeout = %s, want %s", tuned.IdleConnTimeout, newClientIdleConnTimeout)
+	}
+
+	// The caller's transport must not be mutated; it is process-wide.
+	if base.MaxIdleConns != 1 {
+		t.Errorf("base transport was mutated: MaxIdleConns = %d, want 1", base.MaxIdleConns)
+	}
+}


### PR DESCRIPTION
Depends on #318. That commit is the first of the two below and will drop out of this diff once it merges — I can't open this against #318's branch directly, since the base ref has to be a branch in this repo and I only have fork access.

The provider's GitHub API usage is not measurable today, which leaves rate limit investigations to guesswork. #318 is the case in point: the fault it fixes was found by adding this counter, not by reasoning about the symptoms, which all pointed the wrong way.

`github_api_requests_total` counts every request by method, templated route and response status.

Status is a label rather than a total because only `304 Not Modified` is exempt from GitHub's primary rate limit. The 304-versus-200 split is what makes conditional request effectiveness visible; a plain request count misleads about budget consumption. Routes are templated against a list of known GitHub API path segments and capped, so cardinality cannot grow with the number of repositories.

It also feeds upjet's external-API counter at the coarser service-and-method shape the AWS, Azure and GCP providers report, so shared dashboards work without knowing anything GitHub-specific.

## Placement

The counter sits closest to the wire, under the conditional-request layer, so a 304 is recorded as a 304 rather than as the unchanged read the caller sees.

That also places it under the rate limiter, which means a request the limiter refuses or parks is correctly absent from the count. That property is what made #318 diagnosable: zero requests recorded while latency sits on a round ceiling is what distinguishes a client-side park from a slow server.

The legacy client resolves its base RoundTripper from `http.DefaultClient` rather than `http.DefaultTransport`, so that seam is wrapped as well. Traffic through `http.DefaultClient` from anywhere else in the process would be counted too; here that is GitHub API traffic, since the Kubernetes clients build their own transports. 🤖