### PR TITLE
feat(clients): read write_delay_ms, read_delay_ms and parallel_requests from the environment

### DIFF
--- a/internal/clients/github.go
+++ b/internal/clients/github.go
@@ -7,6 +7,8 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -48,6 +50,17 @@ const (
 	keyRetryDelayMs          = "retry_delay_ms"
 	keyMaxRetries            = "max_retries"
 	keyRetryableErrors       = "retryable_errors"
+	keyParallelRequests      = "parallel_requests"
+
+	// write_delay_ms, read_delay_ms and parallel_requests have no environment
+	// variable in terraform-provider-github, unlike legacy_client. This provider
+	// passes an explicit configuration map to the Terraform provider, so schema
+	// defaults do not apply to keys it sets — an operator has no way to reach
+	// these settings without a credentials Secret rotation. These env vars give
+	// them one.
+	envWriteDelayMs     = "GITHUB_WRITE_DELAY_MS"
+	envReadDelayMs      = "GITHUB_READ_DELAY_MS"
+	envParallelRequests = "GITHUB_PARALLEL_REQUESTS"
 )
 
 type appAuth struct {
@@ -98,7 +111,13 @@ func setCredentialConfigs(creds githubConfig, cnf terraform.ProviderConfiguratio
 	return cnf, nil
 }
 
-// setParameterConfigs will add configuration type fields (WriteDelayMs, ReadDelayMs, RetryDelayMs, MaxRetries, RetryableErrors) to terraform providerConfiguration
+// setParameterConfigs adds the configuration fields this provider passes through
+// to terraform-provider-github: write_delay_ms, read_delay_ms, retry_delay_ms,
+// max_retries, retryable_errors and parallel_requests.
+//
+// write_delay_ms and read_delay_ms fall back to the environment when the
+// credentials Secret doesn't set them, and the environment wins when both are
+// present — see envWriteDelayMs and envReadDelayMs.
 func setParameterConfigs(creds githubConfig, cnf terraform.ProviderConfiguration) terraform.ProviderConfiguration {
 	if creds.WriteDelayMs != nil {
 		cnf[keyWriteDelayMs] = *creds.WriteDelayMs
@@ -106,6 +125,20 @@ func setParameterConfigs(creds githubConfig, cnf terraform.ProviderConfiguration
 
 	if creds.ReadDelayMs != nil {
 		cnf[keyReadDelayMs] = *creds.ReadDelayMs
+	}
+
+	if ms, ok := envInt(envWriteDelayMs); ok {
+		cnf[keyWriteDelayMs] = ms
+	}
+
+	if ms, ok := envInt(envReadDelayMs); ok {
+		cnf[keyReadDelayMs] = ms
+	}
+
+	// Only set when true. false is already the upstream default, and writing it
+	// explicitly would be indistinguishable from an operator asking for it.
+	if parallelRequestsEnabled() {
+		cnf[keyParallelRequests] = true
 	}
 
 	if creds.RetryDelayMs != nil {
@@ -121,6 +154,42 @@ func setParameterConfigs(creds githubConfig, cnf terraform.ProviderConfiguration
 	}
 
 	return cnf
+}
+
+// parallelRequestsEnabled reports whether terraform-provider-github's legacy
+// client should skip the process-wide mutex that otherwise serializes every API
+// call (RateLimitTransport.smartLock, honoured only when legacy_client is true).
+// parallel_requests has no environment variable upstream, unlike legacy_client,
+// so this is the only way to set it without a credentials Secret rotation.
+//
+// Enabling it also makes the legacy transport's inter-request delay racy: that
+// delay is shared mutable state guarded by the very mutex this skips. Set both
+// write_delay_ms and read_delay_ms to 0 alongside it, and pace requests with
+// --max-reconcile-rate instead.
+func parallelRequestsEnabled() bool {
+	v, ok := os.LookupEnv(envParallelRequests)
+	if !ok {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return enabled
+}
+
+// envInt reads a non-negative integer from the environment, reporting whether a
+// usable value was found.
+func envInt(name string) (int, bool) {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 func terraformProviderConfigurationBuilder(creds githubConfig) (terraform.ProviderConfiguration, error) {

--- a/internal/clients/github_test.go
+++ b/internal/clients/github_test.go
@@ -140,3 +140,73 @@ func TestTFSetupCacheTTLOutlivedByToken(t *testing.T) {
 			tfSetupMaxHold, githubInstallationTokenLifetime, got-githubInstallationTokenLifetime)
 	}
 }
+
+func TestSetParameterConfigsEnvOverrides(t *testing.T) {
+	ms := func(n int) *int { return &n }
+
+	for _, tc := range []struct {
+		name  string
+		creds githubConfig
+		env   map[string]string
+		want  terraform.ProviderConfiguration
+	}{
+		{
+			name:  "credentials are used when the environment is silent",
+			creds: githubConfig{WriteDelayMs: ms(1000), ReadDelayMs: ms(50)},
+			want:  terraform.ProviderConfiguration{keyWriteDelayMs: 1000, keyReadDelayMs: 50},
+		},
+		{
+			// The point of the override: reaching write_delay_ms, read_delay_ms
+			// and parallel_requests should not require a credentials Secret edit.
+			name:  "the environment wins over the credentials Secret",
+			creds: githubConfig{WriteDelayMs: ms(1000), ReadDelayMs: ms(50)},
+			env:   map[string]string{envWriteDelayMs: "0", envReadDelayMs: "0"},
+			want:  terraform.ProviderConfiguration{keyWriteDelayMs: 0, keyReadDelayMs: 0},
+		},
+		{
+			name: "the environment alone is enough",
+			env:  map[string]string{envWriteDelayMs: "250"},
+			want: terraform.ProviderConfiguration{keyWriteDelayMs: 250},
+		},
+		{
+			name:  "an unparseable or negative delay leaves the credentials value alone",
+			creds: githubConfig{WriteDelayMs: ms(1000)},
+			env:   map[string]string{envWriteDelayMs: "soon", envReadDelayMs: "-1"},
+			want:  terraform.ProviderConfiguration{keyWriteDelayMs: 1000},
+		},
+		{
+			name: "parallel_requests is set only when asked for",
+			env:  map[string]string{envParallelRequests: "true"},
+			want: terraform.ProviderConfiguration{keyParallelRequests: true},
+		},
+		{
+			// Writing false explicitly would be indistinguishable from an operator
+			// requesting it, and false is already the upstream default.
+			name: "parallel_requests false is left unset",
+			env:  map[string]string{envParallelRequests: "false"},
+			want: terraform.ProviderConfiguration{},
+		},
+		{
+			name: "an unparseable parallel_requests is left unset",
+			env:  map[string]string{envParallelRequests: "yes please"},
+			want: terraform.ProviderConfiguration{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			got := setParameterConfigs(tc.creds, terraform.ProviderConfiguration{})
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("config = %v, want %v", got, tc.want)
+			}
+			for k, want := range tc.want {
+				if got[k] != want {
+					t.Errorf("config[%q] = %v, want %v", k, got[k], want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

terraform-provider-github's legacy client serializes every API call through a process-wide mutex (`RateLimitTransport.smartLock`). `parallel_requests` skips that mutex, and it's honoured on the legacy path — it's ignored only when `legacy_client` is `false`.

`parallel_requests`, `write_delay_ms` and `read_delay_ms` have no environment variable upstream, unlike `legacy_client`. This provider also passes an explicit configuration map into the Terraform provider, so schema defaults never apply to keys it sets — the only way to reach these settings today is a credentials Secret edit. This PR reads all three from the environment as well, so they can be tuned from a deployment.

The environment takes precedence over the credentials Secret for the two delays, so existing Secrets keep working and an override is still possible. `parallel_requests` is written only when `true`: `false` is already the upstream default, and writing it explicitly would be indistinguishable from an operator asking for it.

## The delays should be zero alongside parallel_requests

Enabling `parallel_requests` makes the legacy transport's inter-request delay racy — it's shared mutable state guarded by the very mutex being skipped. Setting both delays to `0` avoids that; use `--max-reconcile-rate` to pace requests instead.

## Verification

`go build`, `go vet`, `go test ./internal/clients/` all green. Tests cover: credentials-only, environment-wins, environment-only, unparseable/negative values, and that `parallel_requests` is set only when true.

Verified against terraform-provider-github v6.13.0 (this repo's pinned version): `parallel_requests` defaults to `false`, and `legacy_client` defaults to `true` via `EnvDefaultFunc("GITHUB_LEGACY_CLIENT", true)`.