### PR TITLE
fix(config): scope github_repository_collaborator's read to the direct grant

### DIFF
--- a/config/direct_grant.go
+++ b/config/direct_grant.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package config
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/crossplane-contrib/provider-upjet-github/internal/directgrant"
+)
+
+// directGrantLookup matches directgrant.Lookup. It is injected so
+// wrapReadForDirectGrant is testable without an HTTP fixture; production
+// wiring supplies directgrant.Lookup itself.
+type directGrantLookup func(ctx context.Context, meta any, repository, login string) (directgrant.DirectGrant, error)
+
+// directGrantLookupTimeout bounds the GraphQL lookup this wrapper makes on
+// every Observe for every collaborator managed resource. The legacy
+// schema.ReadFunc signature gives this wrapper no caller context to inherit
+// a deadline from, but nothing prevents bounding its own call: without a
+// timeout, a hung request blocks the reconciling goroutine indefinitely. A
+// timeout surfaces as an ordinary lookup error, which the fail-safe path
+// below already handles correctly (state left untouched, ID never cleared).
+// 30s is generous for a single GraphQL request and short enough that a
+// stuck call does not stall a reconcile for long.
+const directGrantLookupTimeout = 30 * time.Second
+
+// wrapReadForDirectGrant wraps github_repository_collaborator's Read so that
+// its result is corrected against a direct-grant lookup (directgrant.Lookup)
+// rather than trusted as-is.
+//
+// Upstream's own Read lists collaborators with no Affiliation filter, so it
+// reports every login with any access to the repository -- including access
+// inherited purely through team or organization membership -- as though it
+// were the direct grant this managed resource represents. Two consequences
+// follow: (1) Observe never reports the resource as gone once team-inherited
+// access exists, wedging deletion (and blocking Create from ever firing) for
+// an MR whose direct grant was already revoked; and (2) REST's role_name is
+// the *effective* role across every source, not the direct grant's own role,
+// so upstream can write the wrong value into the permission attribute
+// whenever a broader team/org role masks a narrower (or different) direct
+// grant.
+//
+// This wrapper corrects both: if no direct grant exists, it clears the ID
+// (SetId("")) so the managed resource can delete cleanly or be recreated; if
+// one does exist, it overwrites permission with the direct grant's own role
+// name, mapped the way upstream's getPermission maps it
+// (github/util_permissions.go:10 at terraform-provider-github v6.13.0):
+// read -> pull, write -> push, every other role name (including custom
+// repository roles) unchanged.
+//
+// Fail-safe direction: a lookup error must never clear the ID. Doing so
+// would drop the delete finalizer across every collaborator managed
+// resource on a single flaky GraphQL call. On lookup error this wrapper
+// returns nil and leaves state exactly as orig set it.
+//
+// invitation_id complicates what "no direct grant found" means. Upstream
+// sets it when AddCollaborator created a pending invitation rather than a
+// completed collaborator, but findRepoInvitation only lists still-open
+// invitations, so once accepted, upstream's Read never touches the field
+// again -- and Plugin-SDK semantics mean a field Read never Sets falls back
+// to the persisted state value, not to empty, so it stays non-empty in state
+// indefinitely after acceptance. The lookup cannot be skipped just because
+// invitation_id is set: that would restore the effective-role bug for every
+// collaborator ever invited. Instead:
+//   - Exists: true clears invitation_id unconditionally, before the
+//     empty-roleName guard below runs -- the grant existing proves the
+//     invitation was accepted regardless of whether roleName is usable, and
+//     this is what makes the signal self-resetting for the next revocation.
+//   - Exists: false with invitation_id still set is ambiguous: a pending
+//     invitee is believed not to appear as a Repository-sourced
+//     permissionSources edge -- inferred from the resource code, not
+//     verified against live GraphQL, since no such invitation was available
+//     to test against -- so it is treated as still-pending -- keep the ID,
+//     change nothing.
+//   - Exists: false with invitation_id empty is unambiguous: SetId("").
+//
+// nolint:staticcheck // SA1019: github_repository_collaborator defines the
+// legacy schema.Resource.Read field (not ReadContext), and the SDK forbids
+// setting both, so the wrapper must operate on the deprecated ReadFunc.
+func wrapReadForDirectGrant(orig schema.ReadFunc, lookup directGrantLookup) schema.ReadFunc { //nolint:staticcheck // SA1019: see above.
+	return func(d *schema.ResourceData, meta interface{}) error {
+		if err := orig(d, meta); err != nil {
+			return err
+		}
+		if d.Id() == "" {
+			// Upstream's own Read already decided the resource is gone
+			// (e.g. neither an invitation nor a collaborator was found, or
+			// the parent repository 404'd). Nothing left to correct.
+			return nil
+		}
+
+		repository := d.Get("repository").(string)
+		login := d.Get("username").(string)
+
+		ctx, cancel := context.WithTimeout(context.Background(), directGrantLookupTimeout)
+		defer cancel()
+
+		grant, err := lookup(ctx, meta, repository, login)
+		if err != nil {
+			// Fail-safe: leave state exactly as orig set it, and log it --
+			// otherwise a lookup that always fails is indistinguishable from
+			// this fix working, since both leave upstream's answer standing.
+			// directgrant.Warn routes to the crossplane-runtime Logger
+			// TerraformSetupBuilder installs (internal/clients/github.go); a
+			// legacy schema.ReadFunc has no logger of its own to use instead.
+			directgrant.Warn("direct-grant lookup failed; leaving upstream's collaborator read unchanged (permission may be the effective role, and a revoked direct grant will not be detected)",
+				"login", login, "repository", repository, "error", err)
+			return nil
+		}
+		if !grant.Exists {
+			if invitationID, _ := d.Get("invitation_id").(string); invitationID != "" {
+				// A still-pending invitee is believed to look exactly like
+				// this, so treat Exists: false as pending rather than gone.
+				return nil
+			}
+			d.SetId("")
+			return nil
+		}
+		// Clearing a stale invitation_id must run before the empty-roleName
+		// guard below, and unconditionally: the grant existing proves any
+		// recorded invitation was accepted regardless of whether roleName is
+		// usable, and clearing it here is what makes the Exists: false branch
+		// above self-resetting.
+		if invitationID, _ := d.Get("invitation_id").(string); invitationID != "" {
+			if err := d.Set("invitation_id", ""); err != nil {
+				return err
+			}
+		}
+		if grant.RoleName == "" {
+			// permission is ForceNew; writing "" here would diff against any
+			// real spec value and force a delete+recreate of a live
+			// collaborator. Fail-safe: leave it as orig set it.
+			return nil
+		}
+		return d.Set("permission", mapDirectGrantRoleName(grant.RoleName))
+	}
+}
+
+// mapDirectGrantRoleName mirrors upstream's getPermission
+// (github/util_permissions.go:10 at terraform-provider-github v6.13.0):
+// some GitHub API routes express permission as "read"/"write"/"admin",
+// others as "pull"/"push"/"admin". A direct grant's role name arrives in the
+// former vocabulary for the two that differ; every other role name --
+// "admin", "triage", "maintain", and any custom repository role -- passes
+// through unchanged. Compared case-insensitively, since GitHub role names
+// (like logins) are case-insensitive.
+// rolePermissionPush is the schema `permission` value upstream's
+// getPermission maps role "write" to (github/util_permissions.go:10 at
+// terraform-provider-github v6.13.0). Named so it can be shared with
+// direct_grant_test.go's many assertions against it, rather than repeating
+// the literal past goconst's threshold.
+const rolePermissionPush = "push"
+
+func mapDirectGrantRoleName(roleName string) string {
+	switch strings.ToLower(roleName) {
+	case "read":
+		return "pull"
+	case "write":
+		return rolePermissionPush
+	default:
+		return roleName
+	}
+}

--- a/config/direct_grant_test.go
+++ b/config/direct_grant_test.go
@@ -1,0 +1,652 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/crossplane-contrib/provider-upjet-github/internal/directgrant"
+)
+
+// collaboratorTestResourceData builds a *schema.ResourceData shaped like
+// github_repository_collaborator's schema (repository, username, permission,
+// invitation_id), pre-populated with a repository/username pair and, unless
+// id is "", an ID.
+func collaboratorTestResourceData(t *testing.T, id string) *schema.ResourceData {
+	t.Helper()
+	r := &schema.Resource{Schema: map[string]*schema.Schema{
+		"repository":    {Type: schema.TypeString, Optional: true},
+		"username":      {Type: schema.TypeString, Optional: true},
+		"permission":    {Type: schema.TypeString, Optional: true},
+		"invitation_id": {Type: schema.TypeString, Optional: true},
+	}}
+	d := r.TestResourceData()
+	if id != "" {
+		d.SetId(id)
+	}
+	if err := d.Set("repository", "some-owner/some-repo"); err != nil {
+		t.Fatalf("set repository: %v", err)
+	}
+	if err := d.Set("username", "some-user"); err != nil {
+		t.Fatalf("set username: %v", err)
+	}
+	return d
+}
+
+// passthroughOrig simulates upstream's Read having already run successfully
+// and left d exactly as it found it (the common case: nothing changed).
+func passthroughOrig(_ *schema.ResourceData, _ interface{}) error {
+	return nil
+}
+
+// A direct grant gone, with team-inherited access retained (lookup ->
+// Exists: false), must clear the ID so Observe reports ResourceExists: false
+// and deletion (or re-Create) can proceed, instead of wedging forever on
+// access that was never a direct grant.
+func TestWrapReadForDirectGrant_ExistsFalseClearsID(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: false}, nil
+	}
+
+	wrapped := wrapReadForDirectGrant(passthroughOrig, lookup)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected ID to be cleared, got %q", d.Id())
+	}
+}
+
+// The identical fixture as ExistsFalseClearsID, but with the lookup
+// reporting Exists: true, must keep its ID. Paired with that test, this
+// proves the wrapper's SetId("") is actually conditioned on the lookup
+// result rather than firing unconditionally (or never). The permission
+// assertion is also load-bearing here, not incidental: against a passthrough
+// (orig-only, no wrapper logic) permission would stay unset, so this is what
+// makes the test fail without a real wrapper rather than passing trivially
+// because nothing ever touches the ID either way.
+func TestWrapReadForDirectGrant_ExistsTrueKeepsID(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: true, RoleName: rolePermissionPush}, nil
+	}
+
+	wrapped := wrapReadForDirectGrant(passthroughOrig, lookup)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if d.Id() != startingID {
+		t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+	}
+	if got := d.Get("permission").(string); got != rolePermissionPush {
+		t.Fatalf("expected permission %q, got %q", rolePermissionPush, got)
+	}
+}
+
+// A direct grant with a non-mapped role name (maintain is not one of
+// upstream's read/write REST vocabulary) is written to state verbatim.
+func TestWrapReadForDirectGrant_SetsRoleNameAsPermission(t *testing.T) {
+	d := collaboratorTestResourceData(t, "some-owner/some-repo:some-user")
+
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: true, RoleName: "maintain"}, nil
+	}
+
+	wrapped := wrapReadForDirectGrant(passthroughOrig, lookup)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got := d.Get("permission").(string); got != "maintain" {
+		t.Fatalf("expected permission %q, got %q", "maintain", got)
+	}
+}
+
+// The role-name mapping must mirror upstream's getPermission
+// (github/util_permissions.go:10 at terraform-provider-github v6.13.0):
+// read->pull, write->push, everything else (including custom repository
+// roles) passed through unchanged. Compared case-insensitively.
+func TestWrapReadForDirectGrant_RoleNameMapping(t *testing.T) {
+	cases := map[string]struct {
+		roleName string
+		want     string
+	}{
+		"read maps to pull":                       {roleName: "read", want: "pull"},
+		"write maps to push":                      {roleName: "write", want: rolePermissionPush},
+		"custom role name passes through":         {roleName: "Custom Repo Role", want: "Custom Repo Role"},
+		"uppercase READ maps case-insensitively":  {roleName: "READ", want: "pull"},
+		"uppercase WRITE maps case-insensitively": {roleName: "WRITE", want: rolePermissionPush},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := collaboratorTestResourceData(t, "some-owner/some-repo:some-user")
+
+			lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+				return directgrant.DirectGrant{Exists: true, RoleName: tc.roleName}, nil
+			}
+
+			wrapped := wrapReadForDirectGrant(passthroughOrig, lookup)
+			if err := wrapped(d, nil); err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if got := d.Get("permission").(string); got != tc.want {
+				t.Fatalf("expected permission %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// The highest-stakes case: a lookup error must never clear the ID. Clearing
+// on error would drop the delete finalizer across every collaborator
+// managed resource on a single flaky GraphQL call. The wrapper must leave
+// state exactly as orig set it: ID preserved, and permission left at
+// whatever orig wrote (here, simulating upstream's own REST-derived
+// permission value that this workaround exists to correct -- but on lookup
+// failure we degrade to that known-buggy value rather than guess).
+//
+// The lookupCalled assertion is load-bearing: without it, a passthrough that
+// never calls lookup at all would satisfy the ID/permission checks
+// trivially (nothing ever touched them). Asserting the lookup really ran
+// before failing is what proves the preservation is deliberate, not absent.
+func TestWrapReadForDirectGrant_LookupErrorPreservesState(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+
+	origSetPermission := func(d *schema.ResourceData, _ interface{}) error {
+		// Simulates upstream's Read having already set permission from its
+		// own (effective-role) REST lookup before our wrapper runs.
+		return d.Set("permission", "admin")
+	}
+
+	lookupCalled := false
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		lookupCalled = true
+		return directgrant.DirectGrant{}, errors.New("GraphQL request failed: 503 Service Unavailable")
+	}
+
+	wrapped := wrapReadForDirectGrant(origSetPermission, lookup)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected nil error (fail-safe degrade, not a hard error), got %v", err)
+	}
+	if !lookupCalled {
+		t.Fatalf("expected the lookup to have been called")
+	}
+	if d.Id() != startingID {
+		t.Fatalf("expected ID to remain %q, got %q -- a lookup error must never clear the ID", startingID, d.Id())
+	}
+	if got := d.Get("permission").(string); got != "admin" {
+		t.Fatalf("expected permission to remain %q (whatever orig set), got %q", "admin", got)
+	}
+}
+
+// orig returning an error must be returned unchanged, with no lookup call at
+// all -- this wrapper is only responsible for correcting a *successful*
+// Read's result against the direct-grant lookup, not for reinterpreting
+// orig's own errors.
+//
+// Deliberately passes against a bare `return orig` stub: on this input (orig
+// errored), the required behaviour -- return orig's error unchanged, call
+// lookup zero times -- is identical to a no-op, so no assertion here can
+// distinguish the two. It was instead verified against a stub that
+// implements the mapping/clearing logic but omits this ordering guard
+// (ignores orig's error and proceeds anyway), which is the realistic bug
+// this test catches.
+func TestWrapReadForDirectGrant_OrigErrorPassedThroughUnchanged(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+
+	wantErr := errors.New("some transport failure")
+	origErr := func(_ *schema.ResourceData, _ interface{}) error {
+		return wantErr
+	}
+
+	lookupCalled := false
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		lookupCalled = true
+		return directgrant.DirectGrant{}, nil
+	}
+
+	wrapped := wrapReadForDirectGrant(origErr, lookup)
+	gotErr := wrapped(d, nil)
+
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("expected error %v to be returned unchanged, got %v", wantErr, gotErr)
+	}
+	if lookupCalled {
+		t.Fatalf("expected lookup not to be called when orig errors")
+	}
+	if d.Id() != startingID {
+		t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+	}
+}
+
+// When orig itself already cleared the ID (upstream decided the resource is
+// gone via its own REST lookup), the wrapper must not call the lookup at all
+// and must leave the ID empty.
+//
+// Same exception as OrigErrorPassedThroughUnchanged, for the same reason: on
+// this input, "do nothing" is the only correct behaviour, so a `return orig`
+// stub cannot be distinguished from a correct implementation here. Verified
+// instead against the same guard-less stub (there, it proceeds to call
+// lookup even though the ID is already empty).
+func TestWrapReadForDirectGrant_OrigClearedID_LookupNeverCalled(t *testing.T) {
+	d := collaboratorTestResourceData(t, "some-owner/some-repo:some-user")
+
+	origClearsID := func(d *schema.ResourceData, _ interface{}) error {
+		d.SetId("")
+		return nil
+	}
+
+	lookupCalled := false
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		lookupCalled = true
+		return directgrant.DirectGrant{}, nil
+	}
+
+	wrapped := wrapReadForDirectGrant(origClearsID, lookup)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if lookupCalled {
+		t.Fatalf("expected lookup not to be called when orig already cleared the ID")
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected ID to remain empty, got %q", d.Id())
+	}
+}
+
+// directgrant.match models roleName as a nullable GraphQL field, and a null
+// decodes to Exists: true, RoleName: "". permission is ForceNew, so writing
+// "" would diff against any real spec value and force a delete and recreate
+// of a live collaborator. This must fail safe the same direction as a lookup
+// error: leave permission exactly as orig set it.
+func TestWrapReadForDirectGrant_EmptyRoleNamePreservesPermission(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+
+	origSetPermission := func(d *schema.ResourceData, _ interface{}) error {
+		return d.Set("permission", rolePermissionPush)
+	}
+
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: true, RoleName: ""}, nil
+	}
+
+	wrapped := wrapReadForDirectGrant(origSetPermission, lookup)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if d.Id() != startingID {
+		t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+	}
+	if got := d.Get("permission").(string); got != rolePermissionPush {
+		t.Fatalf("expected permission to remain %q (whatever orig set), got %q -- an empty role name must not overwrite it", rolePermissionPush, got)
+	}
+}
+
+// invitation_id, once set by upstream's findRepoInvitation branch, is never
+// Set back to empty by upstream's own Read once the invitation is accepted
+// (ListInvitations only lists still-open invitations, so the
+// accepted-collaborator branch never touches the field again). Plugin-SDK
+// ResourceData semantics mean a field a Read never Sets falls back to the
+// persisted state value, not to empty, so invitation_id stays non-empty in
+// state indefinitely after acceptance -- skipping the lookup whenever it is
+// set would therefore read as "still pending" forever and silently restore
+// the upstream bug for every collaborator that was ever invited.
+//
+// The lookup must always run and, on a confirmed direct grant, clear the
+// stale invitation_id alongside setting permission -- a confirmed grant
+// means any recorded invitation has been accepted and is gone.
+func TestWrapReadForDirectGrant_PreviouslyPendingNowAccepted_ClearsStaleInvitationID(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+	if err := d.Set("invitation_id", "123456"); err != nil {
+		t.Fatalf("set invitation_id: %v", err)
+	}
+
+	// orig here represents upstream's Read having taken the
+	// accepted-collaborator branch (ListCollaborators found the user), which
+	// never Sets invitation_id -- so it falls back to the persisted state
+	// value above, exactly as ResourceData does for an untouched field.
+	origAcceptedCollaborator := passthroughOrig
+
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: true, RoleName: rolePermissionPush}, nil
+	}
+
+	wrapped := wrapReadForDirectGrant(origAcceptedCollaborator, lookup)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if d.Id() != startingID {
+		t.Fatalf("expected ID to remain %q, got %q", startingID, d.Id())
+	}
+	if got := d.Get("permission").(string); got != rolePermissionPush {
+		t.Fatalf("expected permission %q, got %q", rolePermissionPush, got)
+	}
+	if got := d.Get("invitation_id").(string); got != "" {
+		t.Fatalf("expected stale invitation_id to be cleared once a direct grant is confirmed, got %q", got)
+	}
+}
+
+// A genuinely still-pending invitation (Exists: false from the lookup,
+// invitation_id still non-empty) must keep both its ID and its
+// invitation_id untouched: the lookup ran, but a still-pending invitee
+// legitimately has no Repository-sourced permission source yet, so "not
+// found" here does not mean "gone."
+func TestWrapReadForDirectGrant_StillPending_KeepsIDAndInvitationID(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+	if err := d.Set("invitation_id", "123456"); err != nil {
+		t.Fatalf("set invitation_id: %v", err)
+	}
+
+	origSetsInvitation := func(d *schema.ResourceData, _ interface{}) error {
+		return d.Set("permission", rolePermissionPush)
+	}
+
+	lookupCalled := false
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		lookupCalled = true
+		return directgrant.DirectGrant{Exists: false}, nil
+	}
+
+	wrapped := wrapReadForDirectGrant(origSetsInvitation, lookup)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !lookupCalled {
+		t.Fatalf("expected the lookup to have been called")
+	}
+	if d.Id() != startingID {
+		t.Fatalf("expected ID to remain %q, got %q -- a still-pending invitation must not be cleared", startingID, d.Id())
+	}
+	if got := d.Get("invitation_id").(string); got != "123456" {
+		t.Fatalf("expected invitation_id to remain %q, got %q", "123456", got)
+	}
+}
+
+// The property that makes the invitation_id guard self-resetting rather than
+// stale-persistent: a resource that was once pending, then had its grant
+// confirmed (clearing invitation_id), must -- on a later read where the
+// lookup reports Exists: false -- reap normally: ID cleared, same as any
+// collaborator with no invitation history. Run as two sequential wrapped
+// calls against the same ResourceData to model the two reconciles in
+// sequence.
+func TestWrapReadForDirectGrant_StaleInvitationClearedThenRevoked_ClearsID(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+	if err := d.Set("invitation_id", "123456"); err != nil {
+		t.Fatalf("set invitation_id: %v", err)
+	}
+
+	confirmedGrant := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: true, RoleName: rolePermissionPush}, nil
+	}
+	wrapped := wrapReadForDirectGrant(passthroughOrig, confirmedGrant)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("first read: expected nil error, got %v", err)
+	}
+	if got := d.Get("invitation_id").(string); got != "" {
+		t.Fatalf("first read: expected invitation_id to be cleared, got %q", got)
+	}
+
+	revoked := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: false}, nil
+	}
+	wrapped = wrapReadForDirectGrant(passthroughOrig, revoked)
+	if err := wrapped(d, nil); err != nil {
+		t.Fatalf("second read: expected nil error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Fatalf("second read: expected ID to be cleared now that the grant is revoked, got %q", d.Id())
+	}
+}
+
+// A confirmed direct grant with an empty roleName must still clear a stale
+// invitation_id. The empty-roleName guard exists only to protect the
+// ForceNew permission attribute from a guessed value -- it says nothing
+// about the invitation, which the confirmed grant has already proven
+// accepted. Returning before the clearing step leaves invitation_id set
+// forever, and the still-pending branch above then reads that leftover
+// value as "still pending" and never reaps the resource: exactly the wedge
+// this wrapper exists to remove, reachable whenever GraphQL reports a null
+// roleName.
+func TestWrapReadForDirectGrant_EmptyRoleNameStillClearsStaleInvitationID(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+	if err := d.Set("permission", rolePermissionPush); err != nil {
+		t.Fatalf("set permission: %v", err)
+	}
+	if err := d.Set("invitation_id", "12345678"); err != nil {
+		t.Fatalf("set invitation_id: %v", err)
+	}
+
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: true, RoleName: ""}, nil
+	}
+
+	if err := wrapReadForDirectGrant(passthroughOrig, lookup)(d, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Id() != startingID {
+		t.Fatalf("ID = %q, want it preserved as %q", d.Id(), startingID)
+	}
+	// permission is left as orig set it: an empty roleName is not actionable
+	// against a ForceNew attribute.
+	if got := d.Get("permission").(string); got != rolePermissionPush {
+		t.Fatalf("permission = %q, want it left as %q", got, rolePermissionPush)
+	}
+	if got := d.Get("invitation_id").(string); got != "" {
+		t.Fatalf("invitation_id = %q, want it cleared: the direct grant is confirmed, so the invitation was accepted and the field is stale", got)
+	}
+}
+
+// Once the stale invitation_id has been cleared on an empty-roleName read, a
+// later revocation must reap the resource rather than reading the leftover
+// invitation as "still pending".
+func TestWrapReadForDirectGrant_EmptyRoleNameThenRevoked_ClearsID(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+	if err := d.Set("invitation_id", "12345678"); err != nil {
+		t.Fatalf("set invitation_id: %v", err)
+	}
+
+	granted := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: true, RoleName: ""}, nil
+	}
+	if err := wrapReadForDirectGrant(passthroughOrig, granted)(d, nil); err != nil {
+		t.Fatalf("first read: unexpected error: %v", err)
+	}
+
+	revoked := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{}, nil
+	}
+	if err := wrapReadForDirectGrant(passthroughOrig, revoked)(d, nil); err != nil {
+		t.Fatalf("second read: unexpected error: %v", err)
+	}
+	if d.Id() != "" {
+		t.Fatalf("ID = %q, want it cleared after the grant was revoked", d.Id())
+	}
+}
+
+// The fail-safe branch must say something. Swallowing every lookup error
+// with no log line makes a credential withdrawal safe but indistinguishable
+// from the fix working. The line has to carry enough identity to be
+// actionable.
+func TestWrapReadForDirectGrant_LookupErrorIsLogged(t *testing.T) {
+	d := collaboratorTestResourceData(t, "some-owner/some-repo:some-user")
+
+	var logged []string
+	directgrant.SetLogger(func(msg string, keysAndValues ...any) {
+		logged = append(logged, fmt.Sprint(append([]any{msg}, keysAndValues...)...))
+	})
+	t.Cleanup(func() { directgrant.SetLogger(nil) })
+
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{}, errors.New("no GraphQL client registered for this ProviderConfig")
+	}
+	if err := wrapReadForDirectGrant(passthroughOrig, lookup)(d, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(logged) == 0 {
+		t.Fatal("the fail-safe branch logged nothing: a credential withdrawal would silently disable the fix")
+	}
+	line := logged[0]
+	for _, want := range []string{"some-owner/some-repo", "some-user", "no GraphQL client registered"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("fail-safe log line %q does not contain %q", line, want)
+		}
+	}
+}
+
+// The happy path must not log. A warning on every successful
+// Observe would be noise at this provider's reconcile rate and would train
+// operators to ignore the line that matters.
+func TestWrapReadForDirectGrant_SuccessDoesNotLog(t *testing.T) {
+	d := collaboratorTestResourceData(t, "some-owner/some-repo:some-user")
+
+	var logged int
+	directgrant.SetLogger(func(string, ...any) { logged++ })
+	t.Cleanup(func() { directgrant.SetLogger(nil) })
+
+	lookup := func(_ context.Context, _ any, _, _ string) (directgrant.DirectGrant, error) {
+		return directgrant.DirectGrant{Exists: true, RoleName: "write"}, nil
+	}
+	if err := wrapReadForDirectGrant(passthroughOrig, lookup)(d, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if logged != 0 {
+		t.Fatalf("expected no log output on the success path, got %d calls", logged)
+	}
+}
+
+// The property that must not regress, asserted end to end against the real
+// directgrant.Lookup rather than a stub. Every GraphQL failure mode
+// -- transport, status, body, GraphQL errors array, credential, truncation --
+// must leave the ID standing. A single one of these reaching SetId("") drops
+// the delete finalizer across every collaborator managed resource at once.
+//
+// The per-layer tests each assert half of this; only wiring the two together
+// shows that no combination of them clears an ID.
+func TestWrapReadForDirectGrant_NoGraphQLFailureClearsID(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+
+	cases := map[string]struct {
+		status int
+		body   string
+		token  directgrant.TokenProvider
+	}{
+		"HTTP 500": {
+			status: http.StatusInternalServerError, body: `{"message":"Internal Server Error"}`,
+		},
+		"HTTP 401 after a credential withdrawal": {
+			status: http.StatusUnauthorized, body: `{"message":"Bad credentials"}`,
+		},
+		"HTTP 403 secondary rate limit": {
+			status: http.StatusForbidden, body: `{"message":"You have exceeded a secondary rate limit"}`,
+		},
+		"GraphQL INSUFFICIENT_SCOPES": {
+			status: http.StatusOK,
+			body:   `{"data":{"repository":null},"errors":[{"type":"INSUFFICIENT_SCOPES","message":"admin:org required"}]}`,
+		},
+		"GraphQL NOT_FOUND": {
+			status: http.StatusOK,
+			body:   `{"data":{"repository":null},"errors":[{"type":"NOT_FOUND","message":"Could not resolve to a Repository"}]}`,
+		},
+		"null repository with no errors array": {
+			status: http.StatusOK, body: `{"data":{"repository":null}}`,
+		},
+		"an intermediary's unrelated 200": {
+			status: http.StatusOK, body: `{"message":"proxy is warming up"}`,
+		},
+		"a non-JSON body": {
+			status: http.StatusOK, body: `<html>502 Bad Gateway</html>`,
+		},
+		"a truncated result with no exact match": {
+			status: http.StatusOK,
+			body: `{"data":{"repository":{"collaborators":{"pageInfo":{"hasNextPage":true},"edges":[
+				{"node":{"login":"some-user-bot"},"permissionSources":[{"roleName":"write","source":{"__typename":"Repository"}}]}
+			]}}}}`,
+		},
+		"a token provider that fails": {
+			status: http.StatusOK,
+			body:   `{"data":{"repository":{"collaborators":{"edges":[]}}}}`,
+			token: func(context.Context) (string, error) {
+				return "", errors.New("cannot mint a GitHub App installation token")
+			},
+		},
+		"a token provider yielding nothing": {
+			status: http.StatusOK,
+			body:   `{"data":{"repository":{"collaborators":{"edges":[]}}}}`,
+			token:  func(context.Context) (string, error) { return "", nil },
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			t.Cleanup(srv.Close)
+
+			token := tc.token
+			if token == nil {
+				token = directgrant.StaticToken("test-token")
+			}
+			meta := new(int)
+			directgrant.Register(meta, srv.URL, token, "some-owner")
+			t.Cleanup(func() { directgrant.Deregister(meta) })
+
+			d := collaboratorTestResourceData(t, startingID)
+			if err := d.Set("permission", rolePermissionPush); err != nil {
+				t.Fatalf("set permission: %v", err)
+			}
+
+			if err := wrapReadForDirectGrant(passthroughOrig, directgrant.Lookup)(d, meta); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d.Id() != startingID {
+				t.Fatalf("ID = %q, want it preserved as %q: a GraphQL failure must never read as a revoked grant", d.Id(), startingID)
+			}
+			if got := d.Get("permission").(string); got != rolePermissionPush {
+				t.Fatalf("permission = %q, want it left as %q", got, rolePermissionPush)
+			}
+		})
+	}
+}
+
+// An unregistered meta must also preserve the ID, and say so.
+func TestWrapReadForDirectGrant_UnregisteredMetaPreservesID(t *testing.T) {
+	const startingID = "some-owner/some-repo:some-user"
+	d := collaboratorTestResourceData(t, startingID)
+
+	var logged []string
+	directgrant.SetLogger(func(msg string, keysAndValues ...any) {
+		logged = append(logged, fmt.Sprint(append([]any{msg}, keysAndValues...)...))
+	})
+	t.Cleanup(func() { directgrant.SetLogger(nil) })
+
+	if err := wrapReadForDirectGrant(passthroughOrig, directgrant.Lookup)(d, new(int)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Id() != startingID {
+		t.Fatalf("ID = %q, want it preserved as %q", d.Id(), startingID)
+	}
+	if len(logged) == 0 || !strings.Contains(logged[0], "no GraphQL client registered") {
+		t.Fatalf("expected the fail-safe to log the unregistered-meta cause, got %v", logged)
+	}
+}

--- a/config/direct_grant_wiring.go
+++ b/config/direct_grant_wiring.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package config
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/crossplane-contrib/provider-upjet-github/internal/directgrant"
+)
+
+// directGrantWorkaroundResourceName is the sole resource
+// wrapReadForDirectGrant (direct_grant.go) applies to:
+// github_repository_collaborator's Read reports effective (not direct)
+// access, and can write the effective role into permission instead of the
+// direct grant's own role -- see direct_grant.go's doc comment for the full
+// rationale.
+const directGrantWorkaroundResourceName = "github_repository_collaborator"
+
+// withDirectGrantWorkaround wraps github_repository_collaborator's Read on
+// the in-memory *schema.Provider so its result is corrected against a
+// direct-grant GraphQL lookup (directgrant.Lookup) rather than trusted
+// as-is. It mutates and returns the same provider so it can be composed
+// inline at the ujconfig.WithTerraformProvider call site.
+//
+// A missing resource, a nil *schema.Resource, or a nil legacy Read field is
+// skipped rather than panicking, so an upstream rename or a switch to
+// ReadContext is a silent no-op here, not a crash.
+func withDirectGrantWorkaround(p *schema.Provider) *schema.Provider {
+	r, ok := p.ResourcesMap[directGrantWorkaroundResourceName]
+	if !ok || r == nil || r.Read == nil { //nolint:staticcheck // SA1019: intentionally wrapping the legacy Read field this resource defines.
+		return p
+	}
+	r.Read = wrapReadForDirectGrant(r.Read, directgrant.Lookup) //nolint:staticcheck // SA1019: see above; the SDK forbids setting ReadContext alongside Read.
+	return p
+}

--- a/config/direct_grant_wiring_test.go
+++ b/config/direct_grant_wiring_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	tpg "github.com/integrations/terraform-provider-github/v6/github"
+)
+
+// TestDirectGrantWorkaroundResourceIsWired guards against the silent-skip
+// failure mode: withDirectGrantWorkaround does
+// `if !ok || r == nil || r.Read == nil { return p }`, so if
+// github_repository_collaborator is renamed, removed, or switches from the
+// legacy Read field to ReadContext upstream, the wrapper would silently stop
+// doing anything at all -- no build failure, no test failure, just a quiet
+// return to the wedging/misreported-permission bug direct_grant.go exists to
+// fix. This builds the real terraform-provider-github provider and asserts
+// the resource is present and still exposes a non-nil legacy Read.
+func TestDirectGrantWorkaroundResourceIsWired(t *testing.T) {
+	p := tpg.NewProvider("dev", "none")()
+	r, ok := p.ResourcesMap[directGrantWorkaroundResourceName]
+	if !ok {
+		t.Fatalf("%q is not a registered terraform-provider-github resource (would be silently skipped by withDirectGrantWorkaround -- renamed key?)", directGrantWorkaroundResourceName)
+	}
+	if r.Read == nil { //nolint:staticcheck // SA1019: verifying the legacy Read field the wrapper depends on is present.
+		t.Fatalf("%q has no legacy Read func; withDirectGrantWorkaround would silently skip it", directGrantWorkaroundResourceName)
+	}
+}
+
+// TestWithDirectGrantWorkaroundReplacesRead asserts the composition:
+// withDirectGrantWorkaround must actually replace
+// github_repository_collaborator's Read function pointer, not merely leave
+// it wired (which the test above already covers).
+func TestWithDirectGrantWorkaroundReplacesRead(t *testing.T) {
+	p := tpg.NewProvider("dev", "none")()
+	before := fmt.Sprintf("%p", p.ResourcesMap[directGrantWorkaroundResourceName].Read) //nolint:staticcheck // SA1019: see above.
+
+	withDirectGrantWorkaround(p)
+
+	after := fmt.Sprintf("%p", p.ResourcesMap[directGrantWorkaroundResourceName].Read) //nolint:staticcheck // SA1019: see above.
+	if after == before {
+		t.Errorf("%q Read was not wrapped (pointer unchanged: %s)", directGrantWorkaroundResourceName, after)
+	}
+}
+
+// TestDirectGrantWorkaroundInstalledOnBothProviders is the test that catches
+// a one-sided edit: github_repository_collaborator's configuration is
+// doubled across config/provider_cluster.go and config/provider_namespaced.go,
+// each composing withDirectGrantWorkaround at its own
+// ujconfig.WithTerraformProvider call site. Wiring only one means the
+// namespaced (or cluster) managed resources keep wedging/misreporting
+// permission silently forever -- nothing else would fail.
+//
+// Each entrypoint is asserted independently against the same freshly built,
+// unwrapped baseline provider's Read pointer for this resource. Because the
+// two subtests share nothing but that baseline, removing the wrapper from
+// either call site alone -- and only that one -- fails this test: dropping it
+// from provider_cluster.go fails only the "cluster" subtest, dropping it from
+// provider_namespaced.go fails only "namespaced". Checking a shared helper
+// (e.g. withDirectGrantWorkaround itself) instead of both real entrypoints
+// would not catch a call site that never invokes it in the first place --
+// which is exactly the failure mode this test exists to catch.
+func TestDirectGrantWorkaroundInstalledOnBothProviders(t *testing.T) {
+	baseline := fmt.Sprintf("%p", tpg.NewProvider("dev", "none")().ResourcesMap[directGrantWorkaroundResourceName].Read) //nolint:staticcheck // SA1019: see above.
+
+	t.Run("cluster", func(t *testing.T) {
+		pc, err := GetProvider(context.Background())
+		if err != nil {
+			t.Fatalf("GetProvider: %v", err)
+		}
+		got := fmt.Sprintf("%p", pc.TerraformProvider.ResourcesMap[directGrantWorkaroundResourceName].Read) //nolint:staticcheck // SA1019: see above.
+		if got == baseline {
+			t.Errorf("GetProvider (cluster): %q Read is not wrapped (pointer matches unwrapped baseline: %s) -- is withDirectGrantWorkaround composed at the WithTerraformProvider call site in provider_cluster.go?", directGrantWorkaroundResourceName, got)
+		}
+	})
+
+	t.Run("namespaced", func(t *testing.T) {
+		pc, err := GetProviderNamespaced(context.Background())
+		if err != nil {
+			t.Fatalf("GetProviderNamespaced: %v", err)
+		}
+		got := fmt.Sprintf("%p", pc.TerraformProvider.ResourcesMap[directGrantWorkaroundResourceName].Read) //nolint:staticcheck // SA1019: see above.
+		if got == baseline {
+			t.Errorf("GetProviderNamespaced: %q Read is not wrapped (pointer matches unwrapped baseline: %s) -- is withDirectGrantWorkaround composed at the WithTerraformProvider call site in provider_namespaced.go?", directGrantWorkaroundResourceName, got)
+		}
+	})
+}

--- a/config/provider_cluster.go
+++ b/config/provider_cluster.go
@@ -62,7 +62,12 @@ func GetProvider(ctx context.Context) (*ujconfig.Provider, error) {
 		ujconfig.WithTerraformPluginSDKIncludeList(resourceList(terraformPluginSDKExternalNameConfigs)),
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithReferenceInjectors([]ujconfig.ReferenceInjector{reference.NewInjector(modulePath)}),
-		ujconfig.WithTerraformProvider(github.NewProvider("dev", "none")()),
+		// withDirectGrantWorkaround installs a schema.ReadFunc that runs on
+		// every future Terraform Read, long after GetProvider's ctx (a
+		// build-time argument, not a per-reconcile one) has gone out of
+		// scope. It derives its own bounded context (directGrantLookupTimeout,
+		// in config/direct_grant.go) at call time instead, deliberately.
+		ujconfig.WithTerraformProvider(withDirectGrantWorkaround(github.NewProvider("dev", "none")())), //nolint:contextcheck // see comment above
 		ujconfig.WithDefaultResourceOptions(
 			resourceConfigurator(),
 		))

--- a/config/provider_namespaced.go
+++ b/config/provider_namespaced.go
@@ -62,7 +62,12 @@ func GetProviderNamespaced(ctx context.Context) (*ujconfig.Provider, error) {
 		ujconfig.WithTerraformPluginSDKIncludeList(resourceList(terraformPluginSDKExternalNameConfigs)),
 		ujconfig.WithFeaturesPackage("internal/features"),
 		ujconfig.WithReferenceInjectors([]ujconfig.ReferenceInjector{reference.NewInjector(modulePath)}),
-		ujconfig.WithTerraformProvider(github.NewProvider("dev", "none")()),
+		// withDirectGrantWorkaround installs a schema.ReadFunc that runs on
+		// every future Terraform Read, long after GetProviderNamespaced's ctx
+		// (a build-time argument, not a per-reconcile one) has gone out of
+		// scope. It derives its own bounded context (directGrantLookupTimeout,
+		// in config/direct_grant.go) at call time instead, deliberately.
+		ujconfig.WithTerraformProvider(withDirectGrantWorkaround(github.NewProvider("dev", "none")())), //nolint:contextcheck // see comment above
 		ujconfig.WithDefaultResourceOptions(
 			resourceConfigurator(),
 		))

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/crossplane/upjet/v2 v2.2.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/integrations/terraform-provider-github/v6 v6.13.0
+	github.com/jferrl/go-githubauth v1.7.0
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.34.3
 	k8s.io/apiextensions-apiserver v0.34.3
@@ -79,7 +80,6 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jferrl/go-githubauth v1.7.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/internal/clients/directgrant.go
+++ b/internal/clients/directgrant.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jferrl/go-githubauth"
+	"github.com/pkg/errors"
+
+	"github.com/crossplane/upjet/v2/pkg/terraform"
+
+	"github.com/crossplane-contrib/provider-upjet-github/internal/directgrant"
+)
+
+// appTokenMintTimeout bounds a GitHub App installation-token mint.
+//
+// It exists because go-githubauth's installationTokenSource captures its
+// context at construction rather than taking one per Token() call, so the
+// per-lookup deadline the Read wrapper sets (directGrantLookupTimeout,
+// config/direct_grant.go) cannot reach the mint. Without this, a hung mint
+// would block the reconciling goroutine indefinitely. A mint failure surfaces
+// as an ordinary lookup error, which the wrapper's fail-safe already handles
+// correctly: state untouched, ID never cleared.
+const appTokenMintTimeout = 30 * time.Second
+
+// registerDirectGrantClient registers a GraphQL client for
+// directgrant.Lookup, keyed by the same meta pointer the config/ Read wrapper
+// is handed. configureNoForkGithubClient is the only place that holds both the
+// credentials (ps.Configuration) and the resulting meta, because
+// github.Owner's v3client/v4client and name are unexported and unreachable
+// from anywhere else.
+//
+// A ProviderConfig with neither a token nor an app_auth block registers
+// nothing, and directgrant.Lookup then fails loudly for that meta rather than
+// silently answering "no direct grant" with no credential to have asked GitHub
+// with.
+func registerDirectGrantClient(ps *terraform.Setup) error {
+	baseURL, _ := ps.Configuration[keyBaseURL].(string)
+	owner, _ := ps.Configuration[keyOwner].(string)
+
+	token, err := directGrantTokenProvider(ps.Configuration, baseURL)
+	if err != nil {
+		return err
+	}
+	if token == nil {
+		return nil
+	}
+
+	endpoint, err := directgrant.GraphQLEndpoint(baseURL)
+	if err != nil {
+		return errors.Wrap(err, "cannot derive GraphQL endpoint for direct-grant lookups")
+	}
+	directgrant.Register(ps.Meta, endpoint, token, owner)
+	return nil
+}
+
+// directGrantTokenProvider builds the TokenProvider for this ProviderConfig's
+// credentials, or returns nil when there are none to build one from.
+//
+// The two credential shapes are the two branches of setCredentialConfigs: a
+// plain token, or an app_auth block. Checking app_auth first and letting a
+// valid block win outright matches upstream's own precedence: it reads the
+// token attribute only when config.AppID is nil (github/provider.go:397-416
+// at v6.13.0). This must authenticate our GraphQL lookup as the same
+// identity the terraform provider itself uses -- GitHub answers 404, and an
+// empty collaborator list, for things a credential cannot see, so a narrower
+// token here could report a live direct grant as absent and reap the managed
+// resource. Gating on the token key alone would also miss app_auth entirely:
+// setCredentialConfigs writes cnf[keyToken] only when creds.Token != nil,
+// and upstream never writes its minted installation token back into this map
+// (p.Configure receives ps.Configuration as read-only input, and
+// GenerateOAuthTokenFromApp assigns to upstream's own internal Config.Token
+// field, a different object).
+func directGrantTokenProvider(cnf terraform.ProviderConfiguration, baseURL string) (directgrant.TokenProvider, error) {
+	if appID, installationID, pemFile, ok := appAuthFromConfiguration(cnf); ok {
+		return appInstallationTokenProvider(appID, installationID, pemFile, baseURL)
+	}
+	if token, _ := cnf[keyToken].(string); token != "" {
+		return directgrant.StaticToken(token), nil
+	}
+	return nil, nil
+}
+
+// appAuthFromConfiguration reads the app_auth block, reporting whether it is
+// complete. setCredentialConfigs is the only writer of this key, and it writes
+// exactly this shape. The completeness check mirrors upstream's validateAppAuth
+// (github/provider.go:711): all three fields, all non-empty, or the block does
+// not count as app authentication at all.
+func appAuthFromConfiguration(cnf terraform.ProviderConfiguration) (appID, installationID, pemFile string, ok bool) {
+	aaList, isList := cnf[keyAppAuth].([]map[string]any)
+	if !isList || len(aaList) == 0 || aaList[0] == nil {
+		return "", "", "", false
+	}
+	aa := aaList[0]
+	appID, _ = aa[keyAppAuthID].(string)
+	installationID, _ = aa[keyAppAuthInstallationID].(string)
+	pemFile, _ = aa[keyAppAuthPemFile].(string)
+	if appID == "" || installationID == "" || pemFile == "" {
+		return "", "", "", false
+	}
+	return appID, installationID, pemFile, true
+}
+
+// appInstallationTokenProvider mints GitHub App installation tokens on demand,
+// through go-githubauth -- already in the module graph, and the library
+// upstream itself uses for this (internal/ghclient/rest.go at
+// terraform-provider-github v6.13.0).
+//
+// The token must be minted per call, not once at configure time. Even though
+// tfSetupCacheTTL keeps this registration well inside the installation
+// token's lifetime today, a captured token would silently stop being
+// refreshed if that ever changed -- and the Read wrapper's fail-safe
+// swallows lookup errors, so an expired captured token would degrade
+// silently rather than loudly. NewInstallationTokenSource already returns a
+// ReuseTokenSourceWithSkew, so the source is built once here and re-mints
+// itself ahead of expiry rather than on every Observe.
+func appInstallationTokenProvider(appID, installationID, pemFile, baseURL string) (directgrant.TokenProvider, error) {
+	id, err := strconv.ParseInt(installationID, 10, 64)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot parse app_auth installation_id %q for direct-grant lookups", installationID)
+	}
+
+	// pem_file carries PEM content, not a path, and upstream un-escapes a
+	// literal \n in it before use (validateAppAuth, github/provider.go:716 at
+	// v6.13.0; the schema description reads "The GitHub App's PEM file
+	// content; `\n` can be used for newlines"). Real newlines are unaffected.
+	pemData := strings.ReplaceAll(pemFile, `\n`, "\n")
+
+	// appID is passed as a string, which go-githubauth uses verbatim as the
+	// JWT issuer -- correct for both an App ID and a Client ID, the two things
+	// GitHub accepts there.
+	appTokenSource, err := githubauth.NewApplicationTokenSource(appID, []byte(pemData))
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot build a GitHub App token source for direct-grant lookups")
+	}
+
+	opts := []githubauth.InstallationTokenSourceOpt{
+		githubauth.WithHTTPClient(&http.Client{Timeout: appTokenMintTimeout}),
+	}
+	if baseURL != "" {
+		// WithBaseURL, not WithEnterpriseURL: the URL is used verbatim, and
+		// RESTEndpoint has already applied the same normalization upstream
+		// applies before its own mint, so both hit the same path.
+		restURL, err := directgrant.RESTEndpoint(baseURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot derive REST endpoint for direct-grant app token minting")
+		}
+		opts = append(opts, githubauth.WithBaseURL(restURL))
+	}
+
+	tokenSource := githubauth.NewInstallationTokenSource(id, appTokenSource, opts...)
+	return func(context.Context) (string, error) {
+		token, err := tokenSource.Token()
+		if err != nil {
+			return "", errors.Wrap(err, "cannot mint a GitHub App installation token for a direct-grant lookup")
+		}
+		return token.AccessToken, nil
+	}, nil
+}

--- a/internal/clients/directgrant_registration_test.go
+++ b/internal/clients/directgrant_registration_test.go
@@ -1,0 +1,355 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/crossplane/upjet/v2/pkg/terraform"
+	"github.com/integrations/terraform-provider-github/v6/github"
+
+	"github.com/crossplane-contrib/provider-upjet-github/internal/directgrant"
+)
+
+// testAppPEM generates a throwaway RSA private key in PKCS#1 PEM form -- the
+// shape a GitHub App's pem_file carries, and what both upstream's
+// generateAppJWT (go-jose) and go-githubauth's ParseRSAPrivateKeyFromPEM
+// accept. No real credential is involved.
+func testAppPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
+
+// appAuthServer stands in for GitHub's installation-token endpoint. It answers
+// any path ending in access_tokens with 201 Created (the status
+// getInstallationAccessToken and go-githubauth both require; a 200 is treated
+// as a failure by each) and a token carrying a real future expiry.
+//
+// The expiry matters: go-githubauth's ReuseTokenSourceWithSkew treats a zero
+// Expiry as "valid forever", so omitting expires_at would silently make this
+// test assert the captured-token behaviour the token provider exists to avoid.
+//
+// The path is matched by suffix so the one server serves both upstream's mint
+// during p.Configure (which routes through GHESRESTAPIPath, "api/v3/", because
+// getBaseURL classifies an httptest host as GHES) and the mint our own token
+// provider makes.
+func appAuthServer(t *testing.T, token string, mints *int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "access_tokens") {
+			http.Error(w, fmt.Sprintf("unexpected path %q", r.URL.Path), http.StatusNotFound)
+			return
+		}
+		atomic.AddInt32(mints, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      token,
+			"expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func appAuthConfiguration(baseURL, pemFile string) terraform.ProviderConfiguration {
+	return terraform.ProviderConfiguration{
+		keyBaseURL: baseURL + "/",
+		keyOwner:   "octo-org",
+		keyAppAuth: []map[string]any{{
+			keyAppAuthID:             "12345",
+			keyAppAuthInstallationID: "67890",
+			keyAppAuthPemFile:        pemFile,
+		}},
+	}
+}
+
+// app_auth is what production uses, and setCredentialConfigs never writes
+// ps.Configuration["token"] on that path -- it writes app_auth and nothing
+// else. Upstream never writes a minted token back either (p.Configure takes
+// ps.Configuration as read-only input, and GenerateOAuthTokenFromApp assigns
+// to its own internal Config.Token). So gating registration on
+// ps.Configuration["token"] would make the whole direct-grant fix a silent
+// no-op in production.
+//
+// This exercises the real configure path end to end and asserts both halves:
+// a client is registered for the resulting meta, and its token provider yields
+// a usable token.
+func TestConfigureNoForkGithubClient_AppAuthRegistersUsableDirectGrantClient(t *testing.T) {
+	const wantToken = "ghs-installation-token"
+	var mints int32
+	srv := appAuthServer(t, wantToken, &mints)
+
+	ps := terraform.Setup{Configuration: appAuthConfiguration(srv.URL, testAppPEM(t))}
+	p := github.NewProvider("dev", "none")()
+
+	if err := configureNoForkGithubClient(context.Background(), &ps, *p, logging.NewNopLogger()); err != nil {
+		t.Fatalf("configureNoForkGithubClient: %v", err)
+	}
+	t.Cleanup(func() { directgrant.Deregister(ps.Meta) })
+
+	if !directgrant.IsRegistered(ps.Meta) {
+		t.Fatal("no direct-grant client registered for an app_auth ProviderConfig: every LookupDirectGrant would fail and the wrapper's fail-safe would silently do nothing")
+	}
+
+	got, err := directgrant.Token(context.Background(), ps.Meta)
+	if err != nil {
+		t.Fatalf("registered token provider failed: %v", err)
+	}
+	if got != wantToken {
+		t.Fatalf("token provider yielded %q, want %q", got, wantToken)
+	}
+	if n := atomic.LoadInt32(&mints); n == 0 {
+		t.Fatal("expected the token provider to mint an installation token")
+	}
+}
+
+// pem_file carries PEM *content*, and upstream's validateAppAuth
+// (provider.go:716 at v6.13.0) un-escapes a literal \n in it before use --
+// "The GitHub App's PEM file content; `\n` can be used for newlines", per the
+// schema description. A ProviderConfig written that way must work here too,
+// or app_auth registration fails for exactly the credential format the
+// upstream docs recommend.
+func TestConfigureNoForkGithubClient_AppAuthEscapedNewlinePEM(t *testing.T) {
+	const wantToken = "ghs-escaped-pem-token"
+	var mints int32
+	srv := appAuthServer(t, wantToken, &mints)
+
+	escaped := strings.ReplaceAll(testAppPEM(t), "\n", `\n`)
+	ps := terraform.Setup{Configuration: appAuthConfiguration(srv.URL, escaped)}
+	p := github.NewProvider("dev", "none")()
+
+	if err := configureNoForkGithubClient(context.Background(), &ps, *p, logging.NewNopLogger()); err != nil {
+		t.Fatalf("configureNoForkGithubClient: %v", err)
+	}
+	t.Cleanup(func() { directgrant.Deregister(ps.Meta) })
+
+	got, err := directgrant.Token(context.Background(), ps.Meta)
+	if err != nil {
+		t.Fatalf("registered token provider failed for a \\n-escaped pem_file: %v", err)
+	}
+	if got != wantToken {
+		t.Fatalf("token provider yielded %q, want %q", got, wantToken)
+	}
+}
+
+// The plain-token path must keep working, and must not mint anything.
+//
+// base_url points at the fixture server for the same reason the app_auth tests
+// do: configureProviderMeta looks the owner up over REST (provider.go:618),
+// and while it tolerates a 404 it fails the whole Configure on anything else.
+func TestConfigureNoForkGithubClient_PlainTokenRegistersStaticProvider(t *testing.T) {
+	var mints int32
+	srv := appAuthServer(t, "unused", &mints)
+
+	ps := terraform.Setup{Configuration: terraform.ProviderConfiguration{
+		keyBaseURL: srv.URL + "/",
+		keyOwner:   "octo-org",
+		keyToken:   "ghp-plain-token",
+	}}
+	p := github.NewProvider("dev", "none")()
+
+	if err := configureNoForkGithubClient(context.Background(), &ps, *p, logging.NewNopLogger()); err != nil {
+		t.Fatalf("configureNoForkGithubClient: %v", err)
+	}
+	t.Cleanup(func() { directgrant.Deregister(ps.Meta) })
+
+	got, err := directgrant.Token(context.Background(), ps.Meta)
+	if err != nil {
+		t.Fatalf("registered token provider failed: %v", err)
+	}
+	if want := "ghp-plain-token"; got != want {
+		t.Fatalf("token provider yielded %q, want %q", got, want)
+	}
+	if n := atomic.LoadInt32(&mints); n != 0 {
+		t.Fatalf("plain-token path minted %d installation tokens, want 0", n)
+	}
+}
+
+// A ProviderConfig carrying both a token and an app_auth block must
+// authenticate the direct-grant lookup the way upstream authenticates itself:
+// as the App. Upstream reads the token attribute only when config.AppID is nil
+// (github/provider.go:405-416 at v6.13.0). Diverging here would point the
+// GraphQL lookup at a different identity than the terraform provider uses --
+// and since GitHub answers 404, and an empty collaborator list, for anything a
+// credential cannot see, a narrower token could report a live direct grant as
+// absent and reap the managed resource.
+func TestConfigureNoForkGithubClient_AppAuthWinsOverToken(t *testing.T) {
+	const wantToken = "ghs-app-wins"
+	var mints int32
+	srv := appAuthServer(t, wantToken, &mints)
+
+	cnf := appAuthConfiguration(srv.URL, testAppPEM(t))
+	cnf[keyToken] = "ghp-should-not-be-used"
+	ps := terraform.Setup{Configuration: cnf}
+	p := github.NewProvider("dev", "none")()
+
+	if err := configureNoForkGithubClient(context.Background(), &ps, *p, logging.NewNopLogger()); err != nil {
+		t.Fatalf("configureNoForkGithubClient: %v", err)
+	}
+	t.Cleanup(func() { directgrant.Deregister(ps.Meta) })
+
+	got, err := directgrant.Token(context.Background(), ps.Meta)
+	if err != nil {
+		t.Fatalf("registered token provider failed: %v", err)
+	}
+	if got != wantToken {
+		t.Fatalf("token provider yielded %q, want the minted installation token %q: app_auth must win over token, as it does upstream", got, wantToken)
+	}
+}
+
+// An incomplete app_auth block never reaches registration at all: upstream
+// rejects it outright rather than falling back to the token attribute
+// (provider.go:406-408), so the whole setup build fails first.
+//
+// This pins that, because it is the reason appAuthFromConfiguration's
+// completeness check cannot be observed choosing the token instead -- the
+// check is defence in depth, not a reachable branch, and a future upstream
+// that softened this error is exactly when it would start to matter.
+func TestConfigureNoForkGithubClient_IncompleteAppAuthIsRejectedUpstream(t *testing.T) {
+	var mints int32
+	srv := appAuthServer(t, "unused", &mints)
+
+	ps := terraform.Setup{Configuration: terraform.ProviderConfiguration{
+		keyBaseURL: srv.URL + "/",
+		keyOwner:   "octo-org",
+		keyToken:   "ghp-plain-token",
+		keyAppAuth: []map[string]any{{
+			keyAppAuthID:             "12345",
+			keyAppAuthInstallationID: "",
+			keyAppAuthPemFile:        "",
+		}},
+	}}
+	p := github.NewProvider("dev", "none")()
+
+	err := configureNoForkGithubClient(context.Background(), &ps, *p, logging.NewNopLogger())
+	if err == nil {
+		t.Fatal("expected an incomplete app_auth block to fail the provider configure")
+	}
+	if !strings.Contains(err.Error(), "app_auth block is set but required fields are missing") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if directgrant.IsRegistered(ps.Meta) {
+		t.Fatal("registered a direct-grant client for a ProviderConfig whose configure failed")
+	}
+}
+
+// No credentials at all registers nothing, so directgrant.Lookup fails loudly
+// for that meta rather than answering "no direct grant" with nothing to have
+// asked GitHub with.
+func TestConfigureNoForkGithubClient_NoCredentialsRegistersNothing(t *testing.T) {
+	var mints int32
+	srv := appAuthServer(t, "unused", &mints)
+
+	ps := terraform.Setup{Configuration: terraform.ProviderConfiguration{
+		keyBaseURL: srv.URL + "/",
+	}}
+	p := github.NewProvider("dev", "none")()
+
+	if err := configureNoForkGithubClient(context.Background(), &ps, *p, logging.NewNopLogger()); err != nil {
+		t.Fatalf("configureNoForkGithubClient: %v", err)
+	}
+	t.Cleanup(func() { directgrant.Deregister(ps.Meta) })
+
+	if directgrant.IsRegistered(ps.Meta) {
+		t.Fatal("registered a direct-grant client with no credentials")
+	}
+}
+
+// A direct-grant client that cannot be built must not fail the whole
+// terraform.Setup. registerDirectGrantClient gained three new error sources
+// with the token provider -- ParseInt on installation_id, the PEM parse, and
+// RESTEndpoint -- and configureNoForkGithubClient is called from the setup
+// cache's build function. Propagating any of them means that ProviderConfig
+// gets no Setup at all and every managed resource under it stops
+// reconciling: strictly worse than the effective-role bug this whole
+// mechanism exists to fix, and the wrong direction for a design whose rule is
+// "degrade to today's known bug, never make things worse."
+//
+// installation_id is the probe because upstream's own Configure does not
+// parse it as an integer, so p.Configure succeeds and control reaches our
+// code -- the realistic production shape being a Secret value with a trailing
+// newline.
+func TestConfigureNoForkGithubClient_UnbuildableClientDoesNotFailSetup(t *testing.T) {
+	// A malformed pem_file is deliberately not a case here: upstream's own
+	// Configure parses the key and rejects it first ("asn1: structure error"), so
+	// that input never reaches our code and failing the setup is upstream's
+	// correct, pre-existing behaviour rather than a regression of ours.
+	cases := map[string]func(terraform.ProviderConfiguration){
+		"installation_id is not an integer": func(cnf terraform.ProviderConfiguration) {
+			cnf[keyAppAuth].([]map[string]any)[0][keyAppAuthInstallationID] = "67890\n"
+		},
+	}
+
+	for name, mangle := range cases {
+		t.Run(name, func(t *testing.T) {
+			var mints int32
+			srv := appAuthServer(t, "ghs-token", &mints)
+			cnf := appAuthConfiguration(srv.URL, testAppPEM(t))
+			mangle(cnf)
+
+			ps := terraform.Setup{Configuration: cnf}
+			p := github.NewProvider("dev", "none")()
+
+			if err := configureNoForkGithubClient(context.Background(), &ps, *p, logging.NewNopLogger()); err != nil {
+				t.Fatalf("configureNoForkGithubClient failed the whole setup build over an unbuildable direct-grant client: %v", err)
+			}
+			t.Cleanup(func() { directgrant.Deregister(ps.Meta) })
+
+			// Nothing registered is the correct degraded state: Lookup then
+			// fails loudly per call and the Read wrapper's fail-safe leaves
+			// upstream's answer standing.
+			if directgrant.IsRegistered(ps.Meta) {
+				t.Fatal("registered a direct-grant client that could not be built")
+			}
+		})
+	}
+}
+
+// A registerDirectGrantClient failure used to report only via log.Printf on
+// the stdlib default logger, which main.go discards
+// (log.Default().SetOutput(io.Discard)) -- so it never reached an operator.
+// This proves the failure now lands in the caller's own Logger, not just a
+// logging.Logger-shaped stub: must fail against an implementation that logs
+// anywhere other than the l it was handed.
+func TestConfigureNoForkGithubClient_UnbuildableClientLogsThroughCallerLogger(t *testing.T) {
+	var mints int32
+	srv := appAuthServer(t, "ghs-token", &mints)
+	cnf := appAuthConfiguration(srv.URL, testAppPEM(t))
+	cnf[keyAppAuth].([]map[string]any)[0][keyAppAuthInstallationID] = "67890\n"
+
+	ps := terraform.Setup{Configuration: cnf}
+	p := github.NewProvider("dev", "none")()
+	logger := &capturingLogger{}
+
+	if err := configureNoForkGithubClient(context.Background(), &ps, *p, logger); err != nil {
+		t.Fatalf("configureNoForkGithubClient: %v", err)
+	}
+	t.Cleanup(func() { directgrant.Deregister(ps.Meta) })
+
+	if !logger.contains("cannot register a direct-grant client") {
+		t.Fatalf("expected the registration failure to be logged through the caller's Logger, got: %v", logger.infos)
+	}
+}

--- a/internal/clients/directgrant_registry_test.go
+++ b/internal/clients/directgrant_registry_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/crossplane/upjet/v2/pkg/terraform"
+
+	"github.com/crossplane-contrib/provider-upjet-github/internal/directgrant"
+)
+
+// When the setup cache rebuilds a ProviderConfig's CachedTerraformSetup,
+// replacing the map entry keyed by configRefName must deregister the
+// superseded entry's setup.Meta, so the direct-grant registry does not grow
+// without bound across setup rebuilds. This must fail against
+// getOrBuildTerraformSetup with the eviction call removed: the old meta would
+// stay resolvable forever.
+func TestDirectGrantRegistryEvictedOnSetupReplacement(t *testing.T) {
+	var lock sync.RWMutex
+	cache := map[string]CachedTerraformSetup{}
+
+	oldMeta := new(int)
+	newMeta := new(int)
+	directgrant.Register(oldMeta, "https://api.github.com/graphql", directgrant.StaticToken("old-token"), "octo-org")
+	directgrant.Register(newMeta, "https://api.github.com/graphql", directgrant.StaticToken("new-token"), "octo-org")
+	t.Cleanup(func() {
+		directgrant.Deregister(oldMeta)
+		directgrant.Deregister(newMeta)
+	})
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+
+	var buildCount int32
+	build := func(meta any) func() (terraform.Setup, error) {
+		return func() (terraform.Setup, error) {
+			atomic.AddInt32(&buildCount, 1)
+			return terraform.Setup{Meta: meta}, nil
+		}
+	}
+
+	if _, err := getOrBuildTerraformSetup(&lock, cache, "pc", clock, time.Minute, build(oldMeta)); err != nil {
+		t.Fatalf("first build: unexpected error: %v", err)
+	}
+	if ok := directgrant.IsRegistered(oldMeta); !ok {
+		t.Fatalf("expected oldMeta to be registered after the first build")
+	}
+
+	// Expire the cache entry so the next call rebuilds and replaces it.
+	now = now.Add(2 * time.Minute)
+	if _, err := getOrBuildTerraformSetup(&lock, cache, "pc", clock, time.Minute, build(newMeta)); err != nil {
+		t.Fatalf("second build: unexpected error: %v", err)
+	}
+
+	if ok := directgrant.IsRegistered(oldMeta); ok {
+		t.Fatalf("expected oldMeta to be evicted from the direct-grant registry after its CachedTerraformSetup was replaced")
+	}
+	if ok := directgrant.IsRegistered(newMeta); !ok {
+		t.Fatalf("expected newMeta to remain registered")
+	}
+}
+
+// build() always registers the new meta (via configureNoForkGithubClient ->
+// registerDirectGrantClient) before getOrBuildTerraformSetup deregisters the
+// superseded entry. That ordering is only safe while a rebuild's meta
+// pointer never equals the one it replaces; if it ever did, deregistering
+// unconditionally would evict the registration just installed rather than a
+// stale one. This pins the guard against that: a rebuild that returns the
+// same meta as the cached entry must leave it registered.
+func TestDirectGrantRegistryNotEvictedWhenRebuildReusesSameMeta(t *testing.T) {
+	var lock sync.RWMutex
+	cache := map[string]CachedTerraformSetup{}
+
+	meta := new(int)
+	directgrant.Register(meta, "https://api.github.com/graphql", directgrant.StaticToken("token"), "octo-org")
+	t.Cleanup(func() { directgrant.Deregister(meta) })
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	build := func() (terraform.Setup, error) { return terraform.Setup{Meta: meta}, nil }
+
+	if _, err := getOrBuildTerraformSetup(&lock, cache, "pc", clock, time.Minute, build); err != nil {
+		t.Fatalf("first build: unexpected error: %v", err)
+	}
+
+	now = now.Add(2 * time.Minute)
+	if _, err := getOrBuildTerraformSetup(&lock, cache, "pc", clock, time.Minute, build); err != nil {
+		t.Fatalf("second build: unexpected error: %v", err)
+	}
+
+	if ok := directgrant.IsRegistered(meta); !ok {
+		t.Fatal("expected meta to remain registered: the rebuild reused the same meta pointer, so it must not be deregistered as if it were superseded")
+	}
+}

--- a/internal/clients/github.go
+++ b/internal/clients/github.go
@@ -22,6 +22,7 @@ import (
 
 	clusterv1beta1 "github.com/crossplane-contrib/provider-upjet-github/apis/cluster/v1beta1"
 	namespacedv1beta1 "github.com/crossplane-contrib/provider-upjet-github/apis/namespaced/v1beta1"
+	"github.com/crossplane-contrib/provider-upjet-github/internal/directgrant"
 )
 
 const (
@@ -174,6 +175,13 @@ const (
 func TerraformSetupBuilder(tfProvider *schema.Provider, l logging.Logger) terraform.SetupFn {
 	var tfSetupLock sync.RWMutex
 	tfSetups := make(map[string]CachedTerraformSetup)
+	// directgrant (config/direct_grant.go) runs inside the terraform SDK's
+	// legacy schema.ReadFunc signature, which carries no crossplane-runtime
+	// Logger of its own. Installing l here, once per controller setup, is
+	// what lets its fail-safe branch log through the same Logger as
+	// everything else in this provider, rather than the stdlib log package
+	// cmd/provider/main.go silences (log.Default().SetOutput(io.Discard)).
+	directgrant.SetLogger(l.Info)
 	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {
 		configRefName, err := getProviderConfigName(mg)
 		if err != nil {
@@ -206,7 +214,7 @@ func TerraformSetupBuilder(tfProvider *schema.Provider, l logging.Logger) terraf
 					return ps, errors.Wrap(err, errProviderConfigurationBuilder)
 				}
 
-				if err := configureNoForkGithubClient(ctx, &ps, *tfProvider); err != nil {
+				if err := configureNoForkGithubClient(ctx, &ps, *tfProvider, l); err != nil {
 					return ps, errors.Wrap(err, "failed to configure the Terraform Github provider meta")
 				}
 
@@ -252,6 +260,15 @@ func getOrBuildTerraformSetup(
 	if err != nil {
 		return terraform.Setup{}, err
 	}
+	// Deregister the superseded entry's direct-grant client before it is
+	// dropped, so the registry (internal/directgrant) does not grow without
+	// bound across setup rebuilds. Guarded against old.setup.Meta == ps.Meta:
+	// build() always registers the new meta before returning, so if a future
+	// upstream ever reused meta pointers across builds, deregistering
+	// unconditionally would evict the registration just installed.
+	if old, ok := cache[configRefName]; ok && old.setup.Meta != ps.Meta {
+		directgrant.Deregister(old.setup.Meta)
+	}
 	cache[configRefName] = CachedTerraformSetup{
 		setup:  &ps,
 		expiry: now().Add(ttl),
@@ -259,7 +276,7 @@ func getOrBuildTerraformSetup(
 	return ps, nil
 }
 
-func configureNoForkGithubClient(ctx context.Context, ps *terraform.Setup, p schema.Provider) error {
+func configureNoForkGithubClient(ctx context.Context, ps *terraform.Setup, p schema.Provider, l logging.Logger) error {
 	// Please be aware that this implementation relies on the schema.Provider
 	// parameter `p` being a non-pointer. This is because normally
 	// the Terraform plugin SDK normally configures the provider
@@ -273,6 +290,24 @@ func configureNoForkGithubClient(ctx context.Context, ps *terraform.Setup, p sch
 		return errors.Errorf("failed to configure the provider: %v", diag)
 	}
 	ps.Meta = p.Meta()
+
+	// Register a GraphQL client for direct-grant lookups against this
+	// ProviderConfig's credentials -- see directgrant.go in this package.
+	//
+	// Deliberately not propagated. configureNoForkGithubClient runs inside the
+	// setup cache's build function, so returning this error would leave the
+	// ProviderConfig with no terraform.Setup at all and stop every managed
+	// resource under it from reconciling -- far worse than the effective-role
+	// bug the direct-grant lookup exists to fix, and the wrong direction for a
+	// design whose rule is to degrade to today's known bug and never past it.
+	//
+	// Nothing gets registered, so directgrant.Lookup fails loudly per call and
+	// the Read wrapper's fail-safe leaves upstream's answer standing -- exactly
+	// the degraded state a withdrawn credential produces, and just as visible.
+	if err := registerDirectGrantClient(ps); err != nil {
+		l.Info("cannot register a direct-grant client for this ProviderConfig; github_repository_collaborator reads will fall back to upstream's effective-role answer (team-inherited access will read as a direct grant)", "error", err)
+	}
+
 	return nil
 }
 

--- a/internal/clients/github_test.go
+++ b/internal/clients/github_test.go
@@ -11,8 +11,41 @@ import (
 	"testing"
 	"time"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 	"github.com/crossplane/upjet/v2/pkg/terraform"
+	"github.com/integrations/terraform-provider-github/v6/github"
+
+	"github.com/crossplane-contrib/provider-upjet-github/internal/directgrant"
 )
+
+// capturingLogger implements logging.Logger, recording every Info call so a
+// test can assert on what actually reached it -- rather than on a
+// logging.Logger-shaped stub that was never wired to anything real.
+type capturingLogger struct {
+	mu    sync.Mutex
+	infos []string
+}
+
+func (l *capturingLogger) Info(msg string, _ ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.infos = append(l.infos, msg)
+}
+
+func (l *capturingLogger) Debug(string, ...any) {}
+
+func (l *capturingLogger) WithValues(...any) logging.Logger { return l }
+
+func (l *capturingLogger) contains(substr string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, m := range l.infos {
+		if strings.Contains(m, substr) {
+			return true
+		}
+	}
+	return false
+}
 
 // TestGetOrBuildTerraformSetup_ConcurrentColdStart reproduces the cold-start
 // thundering-herd bug: when many managed resources reconcile at once against a
@@ -138,5 +171,27 @@ func TestTFSetupCacheTTLOutlivedByToken(t *testing.T) {
 	if got := tfSetupCacheTTL + tfSetupMaxHold; got > githubInstallationTokenLifetime {
 		t.Errorf("a Setup taken at the end of the TTL and held for %s outlives its %s token by %s; lower tfSetupCacheTTL",
 			tfSetupMaxHold, githubInstallationTokenLifetime, got-githubInstallationTokenLifetime)
+	}
+}
+
+// TerraformSetupBuilder installs its Logger into directgrant.SetLogger, so
+// wrapReadForDirectGrant's fail-safe (config/direct_grant.go) can report
+// through the same Logger as everything else in this provider. That wrapper
+// has no logger of its own to use instead -- it runs inside the terraform
+// SDK's legacy schema.ReadFunc signature -- so without this wiring its
+// failures would go to the stdlib log package, which cmd/provider/main.go
+// discards (log.Default().SetOutput(io.Discard)).
+//
+// Must fail against a build that never calls directgrant.SetLogger:
+// directgrant.Warn would then be a silent no-op.
+func TestTerraformSetupBuilder_InstallsDirectGrantLogger(t *testing.T) {
+	logger := &capturingLogger{}
+	_ = TerraformSetupBuilder(github.NewProvider("dev", "none")(), logger)
+	t.Cleanup(func() { directgrant.SetLogger(nil) })
+
+	directgrant.Warn("simulated direct-grant failure")
+
+	if !logger.contains("simulated direct-grant failure") {
+		t.Fatal("expected TerraformSetupBuilder to install its Logger into directgrant.SetLogger")
 	}
 }

--- a/internal/directgrant/directgrant.go
+++ b/internal/directgrant/directgrant.go
@@ -1,0 +1,534 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package directgrant
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// DirectGrant reports whether a login holds a direct (repository-sourced)
+// grant, as opposed to access inherited through team or organization
+// membership. REST's role_name cannot answer this -- it reports the
+// effective role across every source, not the direct grant specifically --
+// which is why this package asks GraphQL's permissionSources instead.
+type DirectGrant struct {
+	Exists   bool
+	RoleName string // the direct grant's role, e.g. "write", "maintain", or a custom repository role name
+}
+
+// Warnf reports an operator-visible warning, in the same shape as
+// crossplane-runtime's logging.Logger.Info -- its only "important" level,
+// there being no Warn. A plain function type rather than logging.Logger
+// itself, so this leaf package does not couple to that dependency.
+type Warnf func(msg string, keysAndValues ...any)
+
+var (
+	warnMu sync.RWMutex
+	warnFn Warnf
+)
+
+// SetLogger installs w as the logger every Warn call routes through,
+// process-wide. TerraformSetupBuilder (internal/clients) calls this once per
+// controller setup with the same crossplane-runtime Logger the rest of the
+// provider uses. Without it, this package's failures would go to the stdlib
+// log package, which cmd/provider/main.go silences
+// (log.Default().SetOutput(io.Discard)).
+func SetLogger(w Warnf) {
+	warnMu.Lock()
+	defer warnMu.Unlock()
+	warnFn = w
+}
+
+// Warn reports an operator-visible warning through whatever logger
+// SetLogger last installed. A logger that was never installed -- true for
+// most tests -- makes this a silent no-op.
+func Warn(msg string, keysAndValues ...any) {
+	warnMu.RLock()
+	w := warnFn
+	warnMu.RUnlock()
+	if w == nil {
+		return
+	}
+	w(msg, keysAndValues...)
+}
+
+// query asks for up to 10 candidate collaborators matching login
+// and their permission provenance. query: is a fuzzy filter (hence first:10
+// and the case-insensitive exact match Lookup does on the result),
+// not an exact lookup, so a returned edge is a candidate, not a match.
+//
+// pageInfo { hasNextPage } is what makes the first:10 bound safe in the other
+// direction. collaborators(query:) matches display names as well as logins, so
+// on a repository with many collaborators a common fragment can push the login
+// we actually want past the window -- and an absent edge is indistinguishable
+// from a revoked grant. When no exact match is found and the connection has
+// more pages, match reports an error rather than "gone", so a live
+// collaborator is never reaped on a truncated answer.
+const query = `query($owner:String!, $name:String!, $login:String!) {
+  repository(owner:$owner, name:$name) {
+    collaborators(first:10, query:$login) {
+      pageInfo { hasNextPage }
+      edges {
+        node { login }
+        permissionSources { roleName source { __typename } }
+      }
+    }
+  }
+}`
+
+type graphQLRequest struct {
+	Query     string            `json:"query"`
+	Variables map[string]string `json:"variables"`
+}
+
+type graphQLError struct {
+	Message string `json:"message"`
+}
+
+type permissionSource struct {
+	RoleName *string `json:"roleName"`
+	Source   struct {
+		Typename string `json:"__typename"`
+	} `json:"source"`
+}
+
+type collaboratorEdge struct {
+	Node struct {
+		Login string `json:"login"`
+	} `json:"node"`
+	PermissionSources []permissionSource `json:"permissionSources"`
+}
+
+type directGrantResponse struct {
+	Data struct {
+		Repository *struct {
+			Collaborators struct {
+				PageInfo struct {
+					HasNextPage bool `json:"hasNextPage"`
+				} `json:"pageInfo"`
+				Edges []collaboratorEdge `json:"edges"`
+			} `json:"collaborators"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []graphQLError `json:"errors"`
+}
+
+// TokenProvider yields the GitHub token to authenticate a direct-grant lookup
+// with, at the moment the lookup is made.
+//
+// It is deliberately a function rather than a captured string. A GitHub App
+// installation token lives one hour, while the terraform setup that produced
+// this registration is cached for up to that same lifetime
+// (tfSetupCacheTTL, internal/clients/github.go). A token captured at
+// registration time would therefore authenticate for only part of that
+// window and 401 for the rest -- and because the Read wrapper's fail-safe
+// swallows lookup errors, that would degrade silently back to the bug this
+// whole mechanism exists to fix. Refresh has to run on the token's clock,
+// not the setup cache's.
+//
+// Note for the app-auth path: the token source underneath (go-githubauth's
+// installationTokenSource) captures its own context at construction, so ctx
+// here does not bound a mint already in flight. internal/clients bounds it
+// with an http.Client timeout instead (appTokenMintTimeout). Both budgets are
+// 30s, so worst case is ~30s per Observe, not 60: a mint that exhausts its
+// own budget has also exhausted the wrapper's directGrantLookupTimeout, so
+// the GraphQL call that follows fails immediately on an already-expired ctx.
+type TokenProvider func(ctx context.Context) (string, error)
+
+// registeredClient is what the registry keeps per ProviderConfig meta: just
+// enough to authenticate and address a GraphQL request, since github.Owner
+// (the meta value Lookup is handed) has all fields unexported and
+// no accessors.
+type registeredClient struct {
+	endpoint string
+	token    TokenProvider
+	owner    string
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[any]registeredClient{}
+)
+
+// Register records the GraphQL endpoint, token provider and
+// ProviderConfig owner for meta (the value returned by
+// schema.Provider.Meta(), which configureNoForkGithubClient assigns to
+// ps.Meta), so Lookup can resolve them later without reaching into
+// github.Owner's unexported fields.
+//
+// Registering with no token provider is refused: Lookup must fail loudly
+// for that meta (fail-safe, never a silent "no direct grant" with no
+// credential to have asked GitHub with). The provider yielding an empty
+// token or an error is caught later, by Token, for the same reason.
+func Register(meta any, endpoint string, token TokenProvider, owner string) {
+	if meta == nil || token == nil {
+		return
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[meta] = registeredClient{endpoint: endpoint, token: token, owner: owner}
+}
+
+// StaticToken adapts a fixed token string to a TokenProvider. It is what the
+// plain-token ProviderConfig path registers; app_auth registers a minting
+// provider instead.
+func StaticToken(token string) TokenProvider {
+	return func(context.Context) (string, error) { return token, nil }
+}
+
+// Deregister removes meta's registry entry, if any. Called
+// when the setup cache evicts the CachedTerraformSetup that produced meta, so
+// the registry does not grow without bound across setup rebuilds.
+func Deregister(meta any) {
+	if meta == nil {
+		return
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	delete(registry, meta)
+}
+
+func lookupClient(meta any) (registeredClient, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	c, ok := registry[meta]
+	return c, ok
+}
+
+// IsRegistered reports whether meta currently has a registered client. It
+// exists so the setup-cache eviction path (internal/clients) can be tested
+// without exporting the registry itself.
+func IsRegistered(meta any) bool {
+	_, ok := lookupClient(meta)
+	return ok
+}
+
+// Token resolves the GitHub token registered for meta, minting a fresh one if
+// that is what the registered provider does.
+//
+// An unregistered meta, a provider that errors, and a provider that yields an
+// empty token are all errors: Register cannot inspect the credential a
+// TokenProvider will eventually produce, so an app whose mint silently
+// returns nothing must be caught here, or an unauthenticated GraphQL request
+// would produce a "no direct grant" answer that gets trusted.
+func Token(ctx context.Context, meta any) (string, error) {
+	c, ok := lookupClient(meta)
+	if !ok {
+		return "", fmt.Errorf("no GraphQL client registered for this ProviderConfig")
+	}
+	token, err := c.token(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve GitHub token for direct-grant lookup: %w", err)
+	}
+	if token == "" {
+		return "", fmt.Errorf("resolved an empty GitHub token for direct-grant lookup")
+	}
+	return token, nil
+}
+
+// Lookup resolves the GraphQL client registered for meta and asks
+// GitHub which permission sources apply to login on repository. repository
+// may be "owner/repo" or a bare "repo", in which case the ProviderConfig's
+// owner is used.
+//
+// Every failure mode -- no registered client, a transport error, a non-200
+// response, an unparseable body, or a populated GraphQL errors array --
+// returns a non-nil error. A nil error with Exists: false means GitHub
+// answered and no Repository-typed permission source exists for login; it
+// never means the answer is unknown. Callers must not read an error as
+// absence of a grant.
+func Lookup(ctx context.Context, meta any, repository, login string) (DirectGrant, error) {
+	c, ok := lookupClient(meta)
+	if !ok {
+		return DirectGrant{}, fmt.Errorf("no GraphQL client registered for this ProviderConfig")
+	}
+
+	owner, name, err := splitRepository(repository, c.owner)
+	if err != nil {
+		return DirectGrant{}, err
+	}
+
+	token, err := Token(ctx, meta)
+	if err != nil {
+		return DirectGrant{}, err
+	}
+
+	reqBody, err := json.Marshal(graphQLRequest{
+		Query: query,
+		Variables: map[string]string{
+			"owner": owner,
+			"name":  name,
+			"login": login,
+		},
+	})
+	if err != nil {
+		return DirectGrant{}, fmt.Errorf("marshal GraphQL request: %w", err)
+	}
+
+	respBody, err := doGraphQLRequest(ctx, c.endpoint, token, reqBody)
+	if err != nil {
+		return DirectGrant{}, err
+	}
+
+	var parsed directGrantResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return DirectGrant{}, fmt.Errorf("decode GraphQL response: %w", err)
+	}
+
+	// A 200 with a populated errors array (e.g. INSUFFICIENT_SCOPES) is a
+	// GraphQL-level failure, not an answer. It must be distinguishable from
+	// "no direct grant" -- returning a non-nil error here is what makes that
+	// so; callers must never read this as Exists: false.
+	if len(parsed.Errors) > 0 {
+		return DirectGrant{}, fmt.Errorf("GraphQL errors: %s", formatGraphQLErrors(parsed.Errors))
+	}
+
+	return match(parsed, login)
+}
+
+// doGraphQLRequest sends reqBody to endpoint, authenticated with token, and
+// returns the raw response body. Split out of Lookup so Lookup's error
+// handling stays within gocyclo's threshold; the request/response handling
+// (build request, execute, read body, check status) is unchanged from what
+// Lookup did inline.
+func doGraphQLRequest(ctx context.Context, endpoint, token string, reqBody []byte) ([]byte, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("build GraphQL request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	// http.DefaultClient, not a bare &http.Client{}: any request-metrics or
+	// rate-limit instrumentation a deployment installs on
+	// http.DefaultClient.Transport should see this GraphQL traffic too,
+	// alongside the terraform clients' REST traffic. A separate client would
+	// make it invisible to that instrumentation.
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("GraphQL request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read GraphQL response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GraphQL request failed: %s: %s", resp.Status, string(respBody))
+	}
+	return respBody, nil
+}
+
+func formatGraphQLErrors(errs []graphQLError) string {
+	msgs := make([]string, 0, len(errs))
+	for _, e := range errs {
+		msgs = append(msgs, e.Message)
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// match finds the edge whose node login matches login
+// case-insensitively -- GitHub logins are case-insensitive, and upstream's
+// schema carries DiffSuppressFunc: caseInsensitive() for this same reason --
+// and reports whether that edge carries a Repository-typed permission source.
+// Team and Organization sources are inherited access and are ignored.
+//
+// query: is a fuzzy filter, so an edge appearing in the response is a
+// candidate, not a confirmed match; only an exact (case-insensitive) login
+// match counts.
+//
+// Two shapes are errors rather than answers, both for the same reason: the
+// caller clears the managed resource's ID on Exists: false, so anything short
+// of a definite "GitHub says there is no direct grant" must not reach it.
+//
+//   - A nil data.repository. A genuinely missing repository comes back as a
+//     GraphQL NOT_FOUND error, which the errors-array check has already
+//     caught, so nothing legitimate arrives here -- but any intermediary
+//     answering 200 with unrelated JSON decodes silently to this zero value.
+//   - No exact match on a truncated connection. See the query constant.
+func match(resp directGrantResponse, login string) (DirectGrant, error) {
+	if resp.Data.Repository == nil {
+		return DirectGrant{}, fmt.Errorf("GraphQL response contained no repository data")
+	}
+	for _, edge := range resp.Data.Repository.Collaborators.Edges {
+		if !strings.EqualFold(edge.Node.Login, login) {
+			continue
+		}
+		// An exact login match is authoritative whether or not the connection
+		// has more pages: a login appears at most once in it, so no later page
+		// can contradict this edge.
+		for _, src := range edge.PermissionSources {
+			if src.Source.Typename == "Repository" {
+				role := ""
+				if src.RoleName != nil {
+					role = *src.RoleName
+				}
+				return DirectGrant{Exists: true, RoleName: role}, nil
+			}
+		}
+		return DirectGrant{}, nil
+	}
+	if resp.Data.Repository.Collaborators.PageInfo.HasNextPage {
+		return DirectGrant{}, fmt.Errorf("no exact match for login %q within the first %d collaborators and more pages remain: the answer is unknown, not absent", login, len(resp.Data.Repository.Collaborators.Edges))
+	}
+	return DirectGrant{}, nil
+}
+
+// splitRepository splits repository into owner and name.
+// "owner/repo" is used verbatim; a bare "repo" falls back to owner, the
+// registered ProviderConfig owner -- needed because github.Owner.name is
+// unexported and unreachable from the caller.
+//
+// The bare form is the production path, not an edge case: upstream's
+// parseRepoName (terraform-provider-github v6.13.0) resolves it against
+// meta.(*Owner).name, which upstream populates in order of precedence:
+// organization attribute, GITHUB_OWNER env var, owner attribute.
+// Our resolution deliberately differs: the owner captured from ProviderConfig
+// at registration time wins, and GITHUB_OWNER is only a fallback when that is
+// empty. This divergence is harmless because under app_auth, setCredentialConfigs
+// (internal/clients/github.go) returns an error when Owner is nil, so the
+// registered owner is always populated and the env fallback is unreachable there.
+func splitRepository(repository, owner string) (string, string, error) {
+	if before, after, found := strings.Cut(repository, "/"); found {
+		if before == "" || after == "" {
+			return "", "", fmt.Errorf("invalid repository %q", repository)
+		}
+		return before, after, nil
+	}
+	if owner == "" {
+		owner = os.Getenv(envGitHubOwner)
+	}
+	if owner == "" {
+		return "", "", fmt.Errorf("repository %q has no owner, no ProviderConfig owner is registered, and %s is unset", repository, envGitHubOwner)
+	}
+	return owner, repository, nil
+}
+
+// envGitHubOwner is terraform-provider-github's own environment variable for
+// the owner setting (github/provider.go at v6.13.0). Upstream's parseRepoName
+// resolves a bare repository name against meta.(*Owner).name in order of
+// precedence: organization attribute, GITHUB_OWNER env var, owner attribute.
+// Our implementation uses the owner captured from ProviderConfig at registration
+// time first, and falls back to this variable only when that is empty -- and
+// that direction matches upstream's behavior when no organization or owner
+// attribute is provided.
+const envGitHubOwner = "GITHUB_OWNER"
+
+// defaultGitHubBaseURL is what terraform-provider-github's own schema
+// defaults base_url to (github/provider.go, DotComAPIURL) when it is absent
+// from the ProviderConfig.
+const defaultGitHubBaseURL = "https://api.github.com/"
+
+// ghesRESTAPIPath is the REST API path suffix a raw GHES base_url normally
+// carries (terraform-provider-github's GHESRESTAPIPath, github/config.go).
+// It is a REST-only path segment -- GraphQL lives at a sibling path, "api/
+// graphql" -- so it must be stripped before appending the GraphQL suffix, or
+// the result doubles it: ".../api/v3/api/graphql".
+const ghesRESTAPIPath = "api/v3/"
+
+const (
+	dotComHost    = "github.com"
+	dotComAPIHost = "api.github.com"
+)
+
+// ghecAPIHostMatch and ghecHostMatch mirror terraform-provider-github's own
+// GHECAPIHostMatch/GHECHostMatch (github/config.go): a GitHub Enterprise
+// Cloud with Data Residency host, in its "api.<slug>.ghe.com" and
+// "<slug>.ghe.com" forms respectively.
+var (
+	ghecAPIHostMatch = regexp.MustCompile(`^api\.[a-zA-Z0-9-]+\.ghe\.com$`)
+	ghecHostMatch    = regexp.MustCompile(`\.ghe\.com$`)
+)
+
+// GraphQLEndpoint derives the GraphQL endpoint from a REST base_url the same
+// way terraform-provider-github derives its own (getBaseURL,
+// github/config.go:187-220, feeding NewGraphQLClient at line 111, at the
+// pinned TERRAFORM_PROVIDER_VERSION v6.13.0). GraphQL lives at a sibling path
+// from REST, not nested under it, so a GHES base_url's REST suffix
+// ("api/v3/") is stripped before "graphql" is appended.
+func GraphQLEndpoint(baseURL string) (string, error) {
+	u, isGHES, err := normalizeBaseURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+	suffix := "graphql"
+	if isGHES {
+		suffix = "api/graphql"
+	}
+	return u.JoinPath(suffix).String(), nil
+}
+
+// RESTEndpoint derives the REST API base the same way, for the one REST call
+// this package's credentials feed: minting a GitHub App installation token.
+// It mirrors upstream's own choice of pathSuffix at provider.go:424-429 --
+// RESTAPIPath ("/") normally, GHESRESTAPIPath ("api/v3/") for GHES -- so that
+// our mint and upstream's hit the same URL.
+func RESTEndpoint(baseURL string) (string, error) {
+	u, isGHES, err := normalizeBaseURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+	suffix := "/"
+	if isGHES {
+		suffix = ghesRESTAPIPath
+	}
+	return u.JoinPath(suffix).String(), nil
+}
+
+// normalizeBaseURL mirrors terraform-provider-github's getBaseURL
+// (github/config.go:187-220 at the pinned TERRAFORM_PROVIDER_VERSION v6.13.0),
+// returning the normalized base and whether the host is a GHES one. The raw
+// base_url this provider stores in ps.Configuration is the unnormalized
+// credential string -- upstream's own p.Configure() normalizes only its
+// internal Config.BaseURL, a separate object -- so callers here must
+// normalize it themselves rather than assume it already happened:
+//   - a bare "github.com" host is rewritten to "api.github.com" (GitHub does
+//     not serve GraphQL, or anything else, at the bare host);
+//   - a GHES base_url's REST suffix ("api/v3/") is stripped, so callers can
+//     append whichever sibling path they need without doubling it.
+//
+// An absent base_url defaults to https://api.github.com/, mirroring the
+// provider's own schema default, rather than upstream's "base url must not
+// be empty" error.
+func normalizeBaseURL(baseURL string) (*url.URL, bool, error) {
+	if baseURL == "" {
+		baseURL = defaultGitHubBaseURL
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid base_url %q: %w", baseURL, err)
+	}
+	// JoinPath("/") is upstream's own normalization step (getBaseURL): it
+	// cleans the path and guarantees a trailing slash, so the suffix check
+	// below (ghesRESTAPIPath) matches regardless of whether the input ended
+	// with one.
+	u = u.JoinPath("/")
+
+	switch {
+	case u.Host == dotComAPIHost:
+	case u.Host == dotComHost:
+		u.Host = dotComAPIHost
+	case ghecAPIHostMatch.MatchString(u.Host):
+	case ghecHostMatch.MatchString(u.Host):
+		u.Host = "api." + u.Host
+	default:
+		// GHES: strip the REST-only suffix a raw GHES base_url carries.
+		u.Path = strings.TrimSuffix(u.Path, ghesRESTAPIPath)
+		return u, true, nil
+	}
+	return u, false, nil
+}

--- a/internal/directgrant/directgrant_test.go
+++ b/internal/directgrant/directgrant_test.go
@@ -1,0 +1,547 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package directgrant
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// testRepoName and testOwner are fixtures shared across the cases below --
+// named so the many table-driven cases asserting against them don't repeat
+// the literal past goconst's threshold.
+const (
+	testRepoName = "hello-world"
+	testOwner    = "octo-org"
+)
+
+// capturedRequest is what a jsonServer records about the last request it
+// received, so tests can assert on the GraphQL request Lookup
+// actually sent (method, Authorization header, body) rather than just its
+// parsed result.
+type capturedRequest struct {
+	method        string
+	authorization string
+	body          []byte
+}
+
+// jsonServer starts an httptest.Server that always answers with status and
+// body, and records the last request it received (via the returned pointer,
+// which the caller reads after Lookup returns).
+func jsonServer(t *testing.T, status int, body string) (*httptest.Server, *capturedRequest) {
+	t.Helper()
+	captured := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		captured.method = r.Method
+		captured.authorization = r.Header.Get("Authorization")
+		captured.body = b
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, captured
+}
+
+// registerTestClient registers a unique meta with the direct-grant registry
+// pointed at srv, and deregisters it when the test ends so the registry does
+// not accumulate entries across the test binary's run.
+func registerTestClient(t *testing.T, endpoint, token, owner string) any {
+	t.Helper()
+	meta := new(int) // any comparable, unique pointer per call
+	Register(meta, endpoint, StaticToken(token), owner)
+	t.Cleanup(func() { Deregister(meta) })
+	return meta
+}
+
+// A Repository-typed permission source is a direct grant; its roleName is
+// returned verbatim.
+func TestLookupDirectGrant_RepositorySourceExists(t *testing.T) {
+	const body = `{"data":{"repository":{"collaborators":{"edges":[
+		{"node":{"login":"octocat"},"permissionSources":[
+			{"roleName":null,"source":{"__typename":"Organization"}},
+			{"roleName":"write","source":{"__typename":"Repository"}}
+		]}
+	]}}}}`
+	srv, captured := jsonServer(t, http.StatusOK, body)
+	meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+	got, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := DirectGrant{Exists: true, RoleName: "write"}
+	if got != want {
+		t.Fatalf("Lookup() = %+v, want %+v", got, want)
+	}
+
+	// The request itself must carry the right shape: POST, bearer auth, and
+	// the owner/name/login split into GraphQL variables.
+	if captured.method != http.MethodPost {
+		t.Errorf("request method = %q, want %q", captured.method, http.MethodPost)
+	}
+	if want := "Bearer test-token"; captured.authorization != want {
+		t.Errorf("Authorization header = %q, want %q", captured.authorization, want)
+	}
+	var sent graphQLRequest
+	if err := json.Unmarshal(captured.body, &sent); err != nil {
+		t.Fatalf("captured body is not valid JSON: %v (%s)", err, captured.body)
+	}
+	if sent.Variables["owner"] != testOwner || sent.Variables["name"] != testRepoName || sent.Variables["login"] != "octocat" {
+		t.Fatalf("unexpected GraphQL variables: %+v", sent.Variables)
+	}
+}
+
+// Only Organization and Team sources, no Repository source, must report
+// Exists: false with a nil error. The login is only inherited access, not a
+// direct grant.
+func TestLookupDirectGrant_OnlyInheritedSources_NoDirectGrant(t *testing.T) {
+	const body = `{"data":{"repository":{"collaborators":{"edges":[
+		{"node":{"login":"octocat"},"permissionSources":[
+			{"roleName":null,"source":{"__typename":"Organization"}},
+			{"roleName":"admin","source":{"__typename":"Team"}}
+		]}
+	]}}}}`
+	srv, _ := jsonServer(t, http.StatusOK, body)
+	meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+	got, err := Lookup(context.Background(), meta, "octo-org/widget-api", "octocat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Exists {
+		t.Fatalf("Lookup() = %+v, want Exists: false (inherited-only access)", got)
+	}
+}
+
+// roleName must be read, not the lossy permission enum -- which cannot
+// express "maintain" at all. This is the case that fails if the
+// implementation reads a permission field instead of roleName.
+func TestLookupDirectGrant_RoleNameNotPermissionEnum(t *testing.T) {
+	const body = `{"data":{"repository":{"collaborators":{"edges":[
+		{"node":{"login":"octocat"},"permissionSources":[
+			{"roleName":"maintain","source":{"__typename":"Repository"}}
+		]}
+	]}}}}`
+	srv, _ := jsonServer(t, http.StatusOK, body)
+	meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+	got, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := DirectGrant{Exists: true, RoleName: "maintain"}
+	if got != want {
+		t.Fatalf("Lookup() = %+v, want %+v", got, want)
+	}
+}
+
+// A custom repository role name must survive verbatim -- roleName is a
+// String, not an enum, precisely so custom repository roles come through.
+func TestLookupDirectGrant_CustomRoleNameSurvivesVerbatim(t *testing.T) {
+	const body = `{"data":{"repository":{"collaborators":{"edges":[
+		{"node":{"login":"octocat"},"permissionSources":[
+			{"roleName":"Custom Repo Role","source":{"__typename":"Repository"}}
+		]}
+	]}}}}`
+	srv, _ := jsonServer(t, http.StatusOK, body)
+	meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+	got, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := DirectGrant{Exists: true, RoleName: "Custom Repo Role"}
+	if got != want {
+		t.Fatalf("Lookup() = %+v, want %+v", got, want)
+	}
+}
+
+// A GraphQL 200 carrying a populated errors array (here the real
+// INSUFFICIENT_SCOPES shape GitHub returns when permissionSources is
+// requested without admin:org) must be a non-nil error. It must never be
+// readable as "no direct grant" -- an error and an absent grant are different
+// facts, and conflating them would let a scope withdrawal masquerade as a
+// legitimate finding of "not a direct grant".
+func TestLookupDirectGrant_GraphQLErrorsArray_IsError(t *testing.T) {
+	const body = `{"data":{"repository":null},"errors":[{"type":"INSUFFICIENT_SCOPES","message":"Your token has not been granted the required scopes to execute this query. The 'permissionSources' field requires one of the following scopes: ['admin:org'], but your token has only been granted the: ['repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens."}]}`
+	srv, _ := jsonServer(t, http.StatusOK, body)
+	meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+	got, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+	if err == nil {
+		t.Fatalf("expected a non-nil error for a populated GraphQL errors array, got DirectGrant %+v", got)
+	}
+	if !strings.Contains(err.Error(), "INSUFFICIENT_SCOPES") && !strings.Contains(err.Error(), "scopes") {
+		t.Fatalf("expected the error to carry the GraphQL error detail, got: %v", err)
+	}
+}
+
+// An HTTP 500, and a 200 whose body is not JSON, must each be a non-nil
+// error.
+func TestLookupDirectGrant_HTTPFailures(t *testing.T) {
+	t.Run("HTTP 500", func(t *testing.T) {
+		srv, _ := jsonServer(t, http.StatusInternalServerError, `{"message":"Internal Server Error"}`)
+		meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+		_, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+		if err == nil {
+			t.Fatal("expected a non-nil error for HTTP 500")
+		}
+	})
+
+	t.Run("non-JSON body", func(t *testing.T) {
+		srv, _ := jsonServer(t, http.StatusOK, `not json at all`)
+		meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+		_, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+		if err == nil {
+			t.Fatal("expected a non-nil error for a non-JSON response body")
+		}
+	})
+}
+
+// query: is a fuzzy filter. An edge for "octocat-bot" is a
+// candidate, not a match, when "octocat" was asked for -- a substring or
+// prefix match here would misreport inherited-only access as a direct grant
+// (or vice versa) for any login that is a fuzzy neighbour of another.
+func TestLookupDirectGrant_FuzzyQueryNearMiss_NotAMatch(t *testing.T) {
+	const body = `{"data":{"repository":{"collaborators":{"edges":[
+		{"node":{"login":"octocat-bot"},"permissionSources":[
+			{"roleName":"write","source":{"__typename":"Repository"}}
+		]}
+	]}}}}`
+	srv, _ := jsonServer(t, http.StatusOK, body)
+	meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+	got, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Exists {
+		t.Fatalf("Lookup() = %+v, want Exists: false (fuzzy near-miss, not a match)", got)
+	}
+}
+
+// An unregistered meta -- no ProviderConfig ever configured a client for it
+// -- must be an error, never a silent "no direct grant".
+func TestLookupDirectGrant_UnregisteredMeta_Errors(t *testing.T) {
+	meta := new(int) // never registered
+
+	_, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+	if err == nil {
+		t.Fatal("expected a non-nil error for an unregistered meta")
+	}
+}
+
+// The GraphQL endpoint must be derived the same way
+// terraform-provider-github derives its own getBaseURL + NewGraphQLClient
+// (github/config.go:187-220, 111 at TERRAFORM_PROVIDER_VERSION v6.13.0):
+// base_url + "/graphql" for github.com (and ghe.com) hosts, base_url +
+// "api/graphql" for GHES hosts, and https://api.github.com/ as the default
+// when base_url is absent.
+//
+// Cases exercise upstream's normalization, which runs before the path
+// suffix is appended, not just the pre-normalized shape:
+//   - a GHES base_url carries the REST suffix "api/v3/"
+//     (GHESRESTAPIPath) -- upstream strips it before appending "api/graphql",
+//     so naively appending would double it: ".../api/v3/api/graphql".
+//   - a bare "github.com" base_url (not "api.github.com") is rewritten to
+//     the API host before "/graphql" is appended; GitHub does not serve
+//     GraphQL at github.com itself.
+//   - a GHEC Data Residency host ("api.<slug>.ghe.com" or "<slug>.ghe.com")
+//     is a distinct branch from the github.com rewrite (ghecHostMatch vs.
+//     dotComHost) and is not GHES, so it takes the plain "graphql" suffix,
+//     not "api/graphql".
+func TestGraphQLEndpoint(t *testing.T) {
+	cases := map[string]struct {
+		baseURL string
+		want    string
+	}{
+		"api.github.com base URL": {
+			baseURL: "https://api.github.com/",
+			want:    "https://api.github.com/graphql",
+		},
+		"bare github.com host is rewritten to api.github.com": {
+			baseURL: "https://github.com/",
+			want:    "https://api.github.com/graphql",
+		},
+		"GHES base URL carrying the api/v3/ REST suffix": {
+			baseURL: "https://ghes.example.com/api/v3/",
+			want:    "https://ghes.example.com/api/graphql",
+		},
+		"absent base_url defaults to github.com": {
+			baseURL: "",
+			want:    "https://api.github.com/graphql",
+		},
+		"GHEC Data Residency API host is used verbatim": {
+			baseURL: "https://api.acme.ghe.com/",
+			want:    "https://api.acme.ghe.com/graphql",
+		},
+		"GHEC Data Residency bare host is rewritten to its api. host": {
+			baseURL: "https://acme.ghe.com/",
+			want:    "https://api.acme.ghe.com/graphql",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := GraphQLEndpoint(tc.baseURL)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("GraphQLEndpoint(%q) = %q, want %q", tc.baseURL, got, tc.want)
+			}
+		})
+	}
+}
+
+// A 200 whose data.repository is null, with no errors array, is not an
+// answer: any intermediary answering 200 with unrelated JSON decodes
+// straight to the zero value. A genuinely missing repository comes back as a
+// GraphQL NOT_FOUND *error*, which the errors-array check already catches --
+// so there is no legitimate shape that reaches here, and treating it as "no
+// direct grant" would let a proxy's error page reap a live collaborator.
+func TestLookup_NullRepository_IsError(t *testing.T) {
+	cases := map[string]string{
+		"data.repository is null":      `{"data":{"repository":null}}`,
+		"data is empty":                `{"data":{}}`,
+		"body is unrelated JSON":       `{"message":"upstream proxy error"}`,
+		"body is an empty JSON object": `{}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv, _ := jsonServer(t, http.StatusOK, body)
+			meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+			got, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+			if err == nil {
+				t.Fatalf("expected a non-nil error for %s, got DirectGrant %+v", name, got)
+			}
+		})
+	}
+}
+
+// collaborators(query:) is bounded at first:10 and matches
+// display names as well as logins, so a real direct grant can fall outside the
+// window on a repository with many collaborators whose names share a fragment.
+// Reporting "gone" there would reap a live collaborator. When no exact login
+// match was found and the connection has more pages, the answer is unknown --
+// which must be an error, not Exists: false.
+func TestLookup_TruncatedResultWithoutMatch_IsError(t *testing.T) {
+	const body = `{"data":{"repository":{"collaborators":{
+		"pageInfo":{"hasNextPage":true},
+		"edges":[
+			{"node":{"login":"octocat-bot"},"permissionSources":[
+				{"roleName":"write","source":{"__typename":"Repository"}}
+			]}
+		]}}}}`
+	srv, _ := jsonServer(t, http.StatusOK, body)
+	meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+	got, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+	if err == nil {
+		t.Fatalf("expected a non-nil error when the result is truncated and no exact login matched, got DirectGrant %+v", got)
+	}
+}
+
+// The inverse: an exact login match is authoritative regardless of
+// hasNextPage -- a login appears at most once in the connection, so later
+// pages cannot contradict it. Erroring here instead would turn every lookup
+// on a large repository into a permanent fail-safe no-op.
+func TestLookup_TruncatedResultWithMatch_IsAnswered(t *testing.T) {
+	const body = `{"data":{"repository":{"collaborators":{
+		"pageInfo":{"hasNextPage":true},
+		"edges":[
+			{"node":{"login":"octocat"},"permissionSources":[
+				{"roleName":"write","source":{"__typename":"Repository"}}
+			]}
+		]}}}}`
+	srv, _ := jsonServer(t, http.StatusOK, body)
+	meta := registerTestClient(t, srv.URL, "test-token", testOwner)
+
+	got, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := DirectGrant{Exists: true, RoleName: "write"}
+	if got != want {
+		t.Fatalf("Lookup() = %+v, want %+v", got, want)
+	}
+}
+
+// The query must actually ask for pageInfo, or hasNextPage is always false
+// and the truncation tests above pass for the wrong reason -- GitHub simply
+// never tells us the result was truncated.
+func TestQueryRequestsPageInfo(t *testing.T) {
+	if !strings.Contains(query, "hasNextPage") {
+		t.Fatal("the GraphQL query does not request pageInfo { hasNextPage }; truncation would be undetectable")
+	}
+}
+
+// splitRepository's branches. The bare-repo branch is the production path,
+// not an edge case: upstream's parseRepoName resolves the owner from
+// meta.(*Owner).name, so the repository attribute this wrapper reads is
+// routinely just "repo".
+func TestSplitRepository(t *testing.T) {
+	cases := map[string]struct {
+		repository string
+		owner      string
+		env        string
+		wantOwner  string
+		wantName   string
+		wantErr    bool
+	}{
+		"owner/repo is used verbatim": {
+			repository: "octo-org/hello-world", owner: "other", wantOwner: testOwner, wantName: testRepoName,
+		},
+		"bare repo falls back to the registered owner": {
+			repository: testRepoName, owner: testOwner, wantOwner: testOwner, wantName: testRepoName,
+		},
+		"bare repo falls back to GITHUB_OWNER when no owner is registered": {
+			repository: testRepoName, owner: "", env: testOwner, wantOwner: testOwner, wantName: testRepoName,
+		},
+		"a registered owner beats GITHUB_OWNER": {
+			repository: testRepoName, owner: testOwner, env: "SomeoneElse", wantOwner: testOwner, wantName: testRepoName,
+		},
+		"bare repo with no owner anywhere is an error": {
+			repository: testRepoName, wantErr: true,
+		},
+		"empty owner segment is invalid": {
+			repository: "/hello-world", owner: testOwner, wantErr: true,
+		},
+		"empty name segment is invalid": {
+			repository: "octo-org/", owner: testOwner, wantErr: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(envGitHubOwner, tc.env)
+			if tc.env == "" {
+				_ = os.Unsetenv(envGitHubOwner)
+			}
+			gotOwner, gotName, err := splitRepository(tc.repository, tc.owner)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("splitRepository(%q, %q) = (%q, %q, nil), want an error", tc.repository, tc.owner, gotOwner, gotName)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotOwner != tc.wantOwner || gotName != tc.wantName {
+				t.Fatalf("splitRepository(%q, %q) = (%q, %q), want (%q, %q)", tc.repository, tc.owner, gotOwner, gotName, tc.wantOwner, tc.wantName)
+			}
+		})
+	}
+}
+
+// The token provider is what authenticates the request, and it is consulted
+// per lookup rather than captured once -- an App installation token lives an
+// hour while the setup cache holds this registration for 24.
+func TestLookup_TokenProviderConsultedPerCall(t *testing.T) {
+	const body = `{"data":{"repository":{"collaborators":{"edges":[]}}}}`
+	srv, captured := jsonServer(t, http.StatusOK, body)
+
+	var calls int
+	meta := new(int)
+	Register(meta, srv.URL, func(context.Context) (string, error) {
+		calls++
+		return fmt.Sprintf("token-%d", calls), nil
+	}, testOwner)
+	t.Cleanup(func() { Deregister(meta) })
+
+	for i := 1; i <= 2; i++ {
+		if _, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat"); err != nil {
+			t.Fatalf("lookup %d: unexpected error: %v", i, err)
+		}
+		if want := fmt.Sprintf("Bearer token-%d", i); captured.authorization != want {
+			t.Fatalf("lookup %d used Authorization %q, want %q", i, captured.authorization, want)
+		}
+	}
+}
+
+// A token provider that fails, or yields an empty token, must be an error --
+// never an unauthenticated request whose "no direct grant" answer would then
+// be trusted. Register cannot inspect the credential a TokenProvider will
+// eventually produce, so this guard has to live here instead.
+func TestLookup_TokenProviderFailure_IsError(t *testing.T) {
+	t.Run("provider errors", func(t *testing.T) {
+		srv, _ := jsonServer(t, http.StatusOK, `{"data":{"repository":{"collaborators":{"edges":[]}}}}`)
+		meta := new(int)
+		Register(meta, srv.URL, func(context.Context) (string, error) {
+			return "", errors.New("mint failed: 500 from GitHub")
+		}, testOwner)
+		t.Cleanup(func() { Deregister(meta) })
+
+		if _, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat"); err == nil {
+			t.Fatal("expected a non-nil error when the token provider fails")
+		}
+	})
+
+	t.Run("provider yields an empty token", func(t *testing.T) {
+		srv, _ := jsonServer(t, http.StatusOK, `{"data":{"repository":{"collaborators":{"edges":[]}}}}`)
+		meta := new(int)
+		Register(meta, srv.URL, func(context.Context) (string, error) { return "", nil }, testOwner)
+		t.Cleanup(func() { Deregister(meta) })
+
+		if _, err := Lookup(context.Background(), meta, "octo-org/hello-world", "octocat"); err == nil {
+			t.Fatal("expected a non-nil error when the token provider yields an empty token")
+		}
+	})
+
+	t.Run("a nil token provider is refused at registration", func(t *testing.T) {
+		meta := new(int)
+		Register(meta, "https://api.github.com/graphql", nil, testOwner)
+		if IsRegistered(meta) {
+			t.Fatal("Register accepted a nil token provider")
+		}
+	})
+}
+
+// Warn must reach the logger SetLogger last installed, and carry the
+// message and structured pairs through unchanged.
+func TestWarn_ReachesInstalledLogger(t *testing.T) {
+	t.Cleanup(func() { SetLogger(nil) })
+
+	var gotMsg string
+	var gotKVs []any
+	SetLogger(func(msg string, keysAndValues ...any) {
+		gotMsg = msg
+		gotKVs = keysAndValues
+	})
+
+	Warn("direct-grant lookup failed", "login", "octocat", "repository", "octo-org/hello-world")
+
+	if gotMsg != "direct-grant lookup failed" {
+		t.Fatalf("logger received message %q, want %q", gotMsg, "direct-grant lookup failed")
+	}
+	want := []any{"login", "octocat", "repository", "octo-org/hello-world"}
+	if len(gotKVs) != len(want) {
+		t.Fatalf("logger received keysAndValues %v, want %v", gotKVs, want)
+	}
+	for i := range want {
+		if gotKVs[i] != want[i] {
+			t.Fatalf("logger received keysAndValues %v, want %v", gotKVs, want)
+		}
+	}
+}
+
+// No logger installed -- the state every test not calling SetLogger runs
+// in, and what a package that never wires TerraformSetupBuilder would see
+// in production -- must make Warn a silent no-op rather than panic.
+func TestWarn_NoLoggerInstalled_NoOp(t *testing.T) {
+	SetLogger(nil)
+	Warn("should not panic", "key", "value")
+}


### PR DESCRIPTION
### Description of your changes

`github_repository_collaborator`'s upstream `Read` (terraform-provider-github v6.13.0,
`github/resource_github_repository_collaborator.go:143`) calls `ListCollaborators` with no
`Affiliation`, so GitHub defaults to `affiliation=all` and access inherited from a team — or from
the organization — is indistinguishable from a direct grant. Two consequences follow:

1. **A deleted collaborator is never reaped.** After the direct grant is removed, `Read` still finds
   the user, so `Observe` returns `ResourceExists: true` and crossplane-runtime re-enters its delete
   branch instead of removing the finalizer. The object terminates forever, re-issuing
   `DELETE /repos/{owner}/{repo}/collaborators/{username}` roughly every 60s.
2. **`Create` never fires on inherited-only access.** Where a user has access only via a team, `Read`
   reports the resource as existing, so a declared direct grant is recorded as intent but never
   enforced.

Scoping the REST read to `affiliation=direct` would fix only the first half. `role_name` is the
*effective* role under every affiliation, so `permission` would still read back as the inherited
role and diff against a `ForceNew` field. GraphQL `permissionSources` answers both: a
`Repository`-typed source is the direct grant, and its `roleName` is that grant's role.

`roleName` rather than either permission enum, deliberately: `PermissionSource.permission` is
`DefaultRepositoryPermissionField` (`NONE READ WRITE ADMIN`), which cannot express `triage` or
`maintain`, and `RepositoryCollaboratorEdge.permission` is `RepositoryPermission`, which carries
those but still cannot express a custom repository role. A direct `maintain` grant read through
either enum comes back as `WRITE` and reproduces the very replacement wedge this removes.

Verified against the live API in both directions before implementing: a login whose access is purely
team-inherited returns `Team` and `Organization` sources and **no** `Repository` source, while a
login with a direct grant returns a `Repository` source whose `roleName` matches what REST reports.

No fork of terraform-provider-github and no `replace` directive: the wrapper is installed on the
in-memory `*schema.Provider` handed to `ujconfig.WithTerraformProvider`. **No regeneration** — this
adds no Terraform schema field, and `Read` is a runtime-only property absent from
`terraform providers schema -json`.

Layers:

- `internal/directgrant` — the GraphQL lookup and the per-ProviderConfig client registry. A **leaf
  package importing nothing from `apis/`**, so it carries no risk of an import cycle through
  `cmd/generator` (which imports `config`).
- `internal/clients/directgrant.go` — credential handling and registration, hooked into the existing
  `configureNoForkGithubClient`. The registry holds a **token provider**, never a captured token: an
  App installation token lives an hour, and while `tfSetupCacheTTL` keeps the setup cache well inside
  that window today, a captured token would stop being refreshed if that ever changed. `app_auth` is
  preferred over `token`, matching upstream's precedence.
- `config/direct_grant.go` — the `Read` wrapper: clears the ID when no direct grant exists, sets
  `permission` from `roleName`, and otherwise fails safe.

**Fail-safe direction is the load-bearing property.** Any GraphQL failure — HTTP error, `errors`
array, unregistered client, malformed body, timeout, token-mint failure — leaves upstream's verdict
standing and never clears the ID. Treating an error as "gone" would drop delete finalizers across
every collaborator MR at once. Degrading to today's known bug is acceptable; that is not. Failures
are reported through `directgrant.Warn`, which `TerraformSetupBuilder` wires to the same
crossplane-runtime `Logger` the rest of the provider uses — the `Read` wrapper has no logger of its
own to use instead, since it runs inside the terraform SDK's legacy `schema.ReadFunc` signature, and
the stdlib `log` package is silenced by `cmd/provider/main.go`
(`log.Default().SetOutput(io.Discard)`).

**Runtime dependency:** `permissionSources` requires `admin:org`. If that is ever withdrawn from the
provider's credential, every lookup fails into the fail-safe and behaviour degrades to the current
bug rather than to anything worse.

### How has this code been tested

`go build ./...`, `go vet ./...` and `go test ./...` are green; each was run directly rather than
taken on trust from the implementation notes. Each test was verified to fail against a passthrough
wrapper — with a couple of documented exceptions in `config/direct_grant_test.go`, where two distinct
inputs ("orig errored" and "orig already cleared the ID") reduce to the same no-op as a correct
implementation and no assertion on those inputs alone can distinguish the two; those are verified
instead against a stub that omits the specific ordering guard being tested.

Coverage spans behaviour (direct grant revoked while team-inherited access remains → ID cleared; a
`maintain` direct grant under an inherited `admin` → `permission` is `maintain`), wiring (the
resource is wired on both the cluster and namespaced provider), and near-miss cases (a fuzzy `query:`
hit that is not a login match; `Team`/`Organization` sources are not direct grants). Also included:
an `app_auth`-shaped `ps.Configuration` fed through the real configure path, asserting a usable
client registers — without which the change would be a silent no-op under `app_auth`, which
`setCredentialConfigs` never writes a `token` key for.

`make generate` was **not** run — this adds no Terraform schema field and no new resource, so nothing
generated changes. The codegen concern (a `config` → `internal/directgrant` edge reaching `apis/`
through `cmd/generator`) was verified out-of-tree instead: `go list -deps ./cmd/generator` does not
reach `apis/` at all.

### Known limitations, carried deliberately

- `roleName` is confirmed populated for base roles. For a direct `triage`, `maintain` or custom-role
  grant it is inference rather than measurement — no such grant was available to measure against.
  Pinned by fixture tests, which is where it would otherwise bite silently.
- A hung app-token mint serializes concurrent `Observe`s for that ProviderConfig behind
  go-githubauth's mutex for up to 30s. Bounded, lands on the fail-safe, no ID cleared.
- `{"data":{"repository":{}}}` and a null `collaborators` still decode as a legitimate "no direct
  grant". The malformed-body guard covers `data.repository == nil` only.
- Fail-safe activations are logged (through the crossplane-runtime `Logger`) but not counted. A
  metric is the recommended follow-up — that is what would make a credential withdrawal visible on a
  dashboard rather than in logs.
- The setup-cache eviction path (`getOrBuildTerraformSetup`) registers the new ProviderConfig's
  direct-grant client before deregistering the superseded one, guarded against the two meta pointers
  being equal. Correct as long as each rebuild gets a fresh meta, which is upstream's current
  behaviour; if a future upstream ever reused meta pointers across builds where the guard didn't
  already cover it, re-verify the ordering.
- A deleted ProviderConfig (never rebuilt again) leaves its `internal/directgrant` registry entry
  resident for the process lifetime — this mirrors the pre-existing setup-cache leak pattern rather
  than introducing a new one.
- `github.com/jferrl/go-githubauth` moves from indirect to direct. It is the library upstream already
  uses for App auth, at the version already in the module graph.
